### PR TITLE
Make the bob example slightly more idiomatic

### DIFF
--- a/bob/example.rs
+++ b/bob/example.rs
@@ -6,7 +6,7 @@ pub fn reply(message: &str) -> &str {
 }
 
 fn is_silence(message: &str) -> bool {
-    message == ""
+    message.is_empty()
 }
 
 fn is_yelling(message: &str) -> bool {


### PR DESCRIPTION
First pull request of hopefully many. :smile: 
The `is_empty` function appears to be used in more rust code, and might be the slightest bit faster as it's just an in-lined length check.