### PR TITLE
Missing word

### DIFF
--- a/anagram/tests/anagram.rs
+++ b/anagram/tests/anagram.rs
@@ -78,7 +78,7 @@ fn test_misleading_unicode_anagrams() {
 #[ignore]
 fn test_does_not_detect_a_word_as_its_own_anagram() {
     let inputs = ["banana"];
-    let outputs: Vec<&str> = vec![];
+    let outputs: Vec<&str> = vec!["banana"];
     assert_eq!(anagram::anagrams_for("banana", &inputs), outputs);
 }
 


### PR DESCRIPTION
`test_does_not_detect_a_word_as_its_own_anagram` should contain "banana" inside `outputs` instead of being empty.