### PR TITLE
robot-name : improve test for name validity

### DIFF
--- a/robot-name/tests/robot-name.rs
+++ b/robot-name/tests/robot-name.rs
@@ -11,8 +11,9 @@ impl Robot {
 */
 
 fn assert_name_matches_pattern(n: &str) {
-    assert!(n[0..2].chars().all(|c| c >= 'A' && c <= 'Z'), "name starts with 2 letters");
-    assert!(n[3..].chars().all(|c| c >= '0' && c <= '9'), "name ends with 3 numbers");
+    assert!(n.len() == 5, "name is exactly 5 characters long");
+    assert!(n[0..2].chars().all(|c| c >= 'A' && c <= 'Z'), "name starts with 2 uppercase letters");
+    assert!(n[2..].chars().all(|c| c >= '0' && c <= '9'), "name ends with 3 numbers");
 }
 
 fn assert_name_is_persistent(r: &robot::Robot) {


### PR DESCRIPTION
According to exercism/exercism.io#2441 , a valid name should be:
  * exactly five letters long
  * start with two upper case letters
  * end with three numeric digits

The previous code had a bug allowing shorter names to pass, as long
as the first two characters where uppercase letters:
    e.g. 'AB' and 'ABC', 'AB1', 'AB*'