### PR TITLE
Fixed false positive with test_multiple_anagrams

### DIFF
--- a/anagram/tests/anagram.rs
+++ b/anagram/tests/anagram.rs
@@ -43,8 +43,11 @@ fn test_detect_anagram() {
 #[ignore]
 fn test_multiple_anagrams() {
     let inputs = ["gallery", "ballerina", "regally", "clergy", "largely", "leading"];
-    let outputs: Vec<&str> = vec!["gallery", "regally", "largely"];
-    assert_eq!(anagram::anagrams_for("allergy", &inputs), outputs);
+    let mut outputs: Vec<&str> = vec!["gallery", "regally", "largely"];
+    outputs.sort();
+    let mut result = anagram::anagrams_for("allergy", &inputs);
+    result.sort();
+    assert_eq!(result, outputs);
 }
 
 #[test]


### PR DESCRIPTION
If the order returned by anagrams_for is different from the test
case's expected output, the test would fail while being correct.

```
---- test_multiple_anagrams stdout ----
        thread 'test_multiple_anagrams' panicked at 'assertion failed: `(left == right)` (left: `["largely", "regally", "gallery"]`, right: `["gallery", "regally", "largely"]`)', tests/anagram.rs:42
```
Ordering both arrays before comparison fixes the false positive.