### PR TITLE
dominoes: add a test with 2 disjoint domino chains

### DIFF
--- a/dominoes/tests/dominoes.rs
+++ b/dominoes/tests/dominoes.rs
@@ -115,3 +115,10 @@ fn ten_elements() {
         DominoMismatch(output) => panic!("Domino mistmatch for input {:?}, output {:?}", input, output),
     }
 }
+
+#[test]
+#[ignore]
+fn two_disjoint_chains() {
+    let input = &vec!((1, 2), (2, 1), (3, 4), (4, 3));
+    assert_eq!(dominoes::chain(&input), None);
+}


### PR DESCRIPTION
I suggest adding this test case as this situation is not currently covered by the tests. I actually had a bug in my code that is triggered by it but not by the current tests, I suspect it could elicit bugs in the code of other participants.