### PR TITLE
Implement Gigasecond exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,6 +11,7 @@
     "allergies",
     "word-count",
     "hamming",
+    "gigasecond",
     "rna-transcription",
     "nucleotide-count",
     "nucleotide-codons",

--- a/exercises/gigasecond/Cargo.lock
+++ b/exercises/gigasecond/Cargo.lock
@@ -1,0 +1,55 @@
+[root]
+name = "gigasecond"
+version = "0.0.0"
+dependencies = [
+ "chrono 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "chrono"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "time"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/exercises/gigasecond/Cargo.toml
+++ b/exercises/gigasecond/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "gigasecond"
+version = "0.0.0"
+
+[dependencies]
+chrono = "0.2"
+

--- a/exercises/gigasecond/example.rs
+++ b/exercises/gigasecond/example.rs
@@ -1,0 +1,6 @@
+extern crate chrono;
+use chrono::*;
+
+pub fn after(start: DateTime<UTC>) -> DateTime<UTC> {
+    start + Duration::seconds(1_000_000_000)
+}

--- a/exercises/gigasecond/tests/gigasecond.rs
+++ b/exercises/gigasecond/tests/gigasecond.rs
@@ -1,6 +1,17 @@
 extern crate gigasecond;
 
-//Note: Your code must also start with the following two lines.
+/*
+ * Students,
+ *
+ * Rust does not currently have a library for handling Time. To solve this exercise
+ * you'll need to use the Chrono 'crate' (which is Rust's term for an external library).
+ *
+ * The first time you run `cargo test`, the Chrono crate will automatically be downloaded
+ * and installed. More information on crates can be found at
+ * https://doc.rust-lang.org/book/guessing-game.html#generating-a-secret-number
+ *
+ * In order to use the crate, your solution will need to start with the two following lines
+*/
 extern crate chrono;
 use chrono::*;
 

--- a/exercises/gigasecond/tests/gigasecond.rs
+++ b/exercises/gigasecond/tests/gigasecond.rs
@@ -1,0 +1,39 @@
+extern crate gigasecond;
+
+//Note: Your code must also start with the following two lines.
+extern crate chrono;
+use chrono::*;
+
+#[test]
+fn test_date() {
+    let start_date = UTC.ymd(2011, 4, 25).and_hms(0,0,0);
+    assert_eq!(gigasecond::after(start_date), UTC.ymd(2043, 1, 1).and_hms(1,46,40));
+}
+
+#[test]
+#[ignore]
+fn test_another_date() {
+    let start_date = UTC.ymd(1977, 6, 13).and_hms(0,0,0);
+    assert_eq!(gigasecond::after(start_date), UTC.ymd(2009, 2, 19).and_hms(1,46,40));
+}
+
+#[test]
+#[ignore]
+fn test_third_date() {
+    let start_date = UTC.ymd(1959, 7, 19).and_hms(0,0,0);
+    assert_eq!(gigasecond::after(start_date), UTC.ymd(1991, 3, 27).and_hms(1,46,40));
+}
+
+#[test]
+#[ignore]
+fn test_datetime() {
+    let start_date = UTC.ymd(2015, 1, 24).and_hms(22,0,0);
+    assert_eq!(gigasecond::after(start_date), UTC.ymd(2046, 10, 2).and_hms(23,46,40));
+}
+
+#[test]
+#[ignore]
+fn test_another_datetime() {
+    let start_date = UTC.ymd(2015, 1, 24).and_hms(23,59,59);
+    assert_eq!(gigasecond::after(start_date), UTC.ymd(2046, 10, 3).and_hms(1,46,39));
+}


### PR DESCRIPTION
Adding the [Gigasecond exercise](http://x.exercism.io/problems/gigasecond) for the Rust track.

This exercise is a little odd in Rust as the core language has no library for dealing with time. There was the Time crate, but that was pulled from the standard library. Based on [this RFC](https://github.com/rust-lang/rfcs/issues/619) from last year, the Chrono crate appears to be the best current library for dealing with time. I've used Chrono here.

Either because I'm still new to Rust, or because of an actual limitation in Chrono, the best way I could write the tests was to have everything be a UTC DateTime. This means that the tests that only use dates still require the slightly weird `.and_hms(0,0,0)` function at the end to make them DateTime-y. I did this because Chrono only seems to support Duration addition for DateTimes, not Dates.