### PR TITLE
rna-transcription: Remove as_ref test

### DIFF
--- a/exercises/rna-transcription/example.rs
+++ b/exercises/rna-transcription/example.rs
@@ -11,12 +11,6 @@ impl RibonucleicAcid {
     }
 }
 
-impl AsRef<str> for RibonucleicAcid {
-    fn as_ref(&self) -> &str {
-        self.nucleotides.as_ref()
-    }
-}
-
 #[derive(PartialEq, Eq, Debug)]
 pub struct DeoxyribonucleicAcid {
     nucleotides: String

--- a/exercises/rna-transcription/tests/rna-transcription.rs
+++ b/exercises/rna-transcription/tests/rna-transcription.rs
@@ -35,10 +35,3 @@ fn test_transcribes_thymine_to_adenine() {
 fn test_transcribes_all_dna_to_rna() {
     assert_eq!(dna::RibonucleicAcid::new("UGCACCAGAAUU"), dna::DeoxyribonucleicAcid::new("ACGTGGTCTTAA").to_rna())
 }
-
-#[test]
-#[ignore]
-fn test_acid_converts_to_string() {
-    assert_eq!(dna::RibonucleicAcid::new("AGC").as_ref(), "AGC");
-    assert_eq!(dna::RibonucleicAcid::new("CGA").as_ref(), "CGA");
-}


### PR DESCRIPTION
This was introduced in 7877d6389ed47d8c3e6631274c1c66a0b4c4ec54 back
when the exercises was ported to xrust, but there's no clear reason why
we would want the RNA to be convertible to a string.

* It's not relevant to the problem statement.
* There's no clear use case for why this is something that should be
  required.
* Other languages don't do this.
* Other exercises in xrust don't do this.

Given these reasons, it makes more sense to remove it.

Closes #76