### PR TITLE
allergies: use Allergies::new for test interface

### DIFF
--- a/exercises/allergies/example.rs
+++ b/exercises/allergies/example.rs
@@ -4,6 +4,10 @@ pub struct Allergies(pub usize);
 pub enum Allergen { Eggs, Peanuts, Shellfish, Strawberries, Tomatoes, Chocolate, Pollen, Cats }
 
 impl Allergies {
+    pub fn new(score: usize) -> Allergies {
+        Allergies(score)
+    }
+
     pub fn is_allergic_to(&self, allergen: &Allergen) -> bool {
         let allergens = Allergies::allergens();
         let index = allergens.iter().position(|x: &Allergen| x == allergen).unwrap();

--- a/exercises/allergies/tests/allergies.rs
+++ b/exercises/allergies/tests/allergies.rs
@@ -4,7 +4,7 @@ use allergies::*;
 
 #[test]
 fn test_no_allergies_means_not_allergic() {
-    let allergies = Allergies(0);
+    let allergies = Allergies::new(0);
     assert_eq!(false, allergies.is_allergic_to(&Allergen::Peanuts));
     assert_eq!(false, allergies.is_allergic_to(&Allergen::Cats));
     assert_eq!(false, allergies.is_allergic_to(&Allergen::Strawberries));
@@ -13,13 +13,13 @@ fn test_no_allergies_means_not_allergic() {
 #[test]
 #[ignore]
 fn test_is_allergic_to_eggs() {
-    assert_eq!(true, Allergies(1).is_allergic_to(&Allergen::Eggs));
+    assert_eq!(true, Allergies::new(1).is_allergic_to(&Allergen::Eggs));
 }
 
 #[test]
 #[ignore]
 fn test_has_the_right_allergies() {
-    let allergies = Allergies(5);
+    let allergies = Allergies::new(5);
     assert_eq!(true, allergies.is_allergic_to(&Allergen::Eggs));
     assert_eq!(true, allergies.is_allergic_to(&Allergen::Shellfish));
     assert_eq!(false, allergies.is_allergic_to(&Allergen::Strawberries));
@@ -28,13 +28,13 @@ fn test_has_the_right_allergies() {
 #[test]
 #[ignore]
 fn test_no_allergies_at_all() {
-    assert_eq!(Vec::<Allergen>::new(), Allergies(0).allergies());
+    assert_eq!(Vec::<Allergen>::new(), Allergies::new(0).allergies());
 }
 
 #[test]
 #[ignore]
 fn test_just_to_peanuts() {
-    assert_eq!(vec![Allergen::Peanuts], Allergies(2).allergies());
+    assert_eq!(vec![Allergen::Peanuts], Allergies::new(2).allergies());
 }
 
 #[test]
@@ -43,11 +43,11 @@ fn test_allergic_to_everything() {
     assert_eq!(vec![Allergen::Eggs, Allergen::Peanuts, Allergen::Shellfish,
                     Allergen::Strawberries, Allergen::Tomatoes, Allergen::Chocolate,
                     Allergen::Pollen, Allergen::Cats],
-        Allergies(255).allergies());
+        Allergies::new(255).allergies());
 }
 
 #[test]
 #[ignore]
 fn test_ignore_non_allergen_score_parts() {
-    assert_eq!(vec![Allergen::Eggs], Allergies(257).allergies());
+    assert_eq!(vec![Allergen::Eggs], Allergies::new(257).allergies());
 }


### PR DESCRIPTION
As mentioned in #64, using Allergies(3) or similar constrains the
implementation to using tuple structs, whereas there could be a range of
possible implementations. By using `new` as the test interface,
implementations can choose what internal representation they'd like. For
instance, the example solution still uses a tuple struct, but you could
imagine solutions using regular structs.

Closes #64 (and I believe this is the only exercise that constrains the
implementation in such a way)