### PR TITLE
travis: test beta and nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,10 @@ script:
 - "./bin/fetch-configlet"
 - "./bin/configlet ."
 sudo: false
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly


### PR DESCRIPTION
A suggestion from https://docs.travis-ci.com/user/languages/rust

The motivation here is simply that we get alerted ahead of time if an
upcoming release of Rust would break our tests for whatever reason. In
such a case we'd like to be alerted of it ahead of time.