### PR TITLE
Change API to borrow piece to can_attack

### DIFF
--- a/exercises/queen-attack/example.rs
+++ b/exercises/queen-attack/example.rs
@@ -11,7 +11,7 @@ impl Queen {
         }
     }
 
-    pub fn can_attack(&self, piece: Queen) -> bool {
+    pub fn can_attack(&self, piece: &Queen) -> bool {
         self.horizontal_from(&piece) ||
             self.vertical_from(&piece) ||
             self.diagonal_from(&piece)

--- a/exercises/queen-attack/tests/queen-attack.rs
+++ b/exercises/queen-attack/tests/queen-attack.rs
@@ -29,7 +29,7 @@ fn test_queen_creation_with_incorrect_positions() {
 fn test_can_not_attack() {
     let white_queen = Queen::new((2,4)).unwrap();
     let black_queen = Queen::new((6,6)).unwrap();
-    assert_eq!(false, white_queen.can_attack(black_queen));
+    assert_eq!(false, white_queen.can_attack(&black_queen));
 }
 
 #[test]
@@ -37,7 +37,7 @@ fn test_can_not_attack() {
 fn test_can_attack_on_same_rank() {
     let white_queen = Queen::new((2,4)).unwrap();
     let black_queen = Queen::new((2,6)).unwrap();
-    assert!(white_queen.can_attack(black_queen));
+    assert!(white_queen.can_attack(&black_queen));
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn test_can_attack_on_same_rank() {
 fn test_can_attack_on_same_file() {
     let white_queen = Queen::new((4,5)).unwrap();
     let black_queen = Queen::new((3,5)).unwrap();
-    assert!(white_queen.can_attack(black_queen));
+    assert!(white_queen.can_attack(&black_queen));
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn test_can_attack_on_same_file() {
 fn test_can_attack_on_first_diagonal() {
     let white_queen = Queen::new((2,2)).unwrap();
     let black_queen = Queen::new((0,4)).unwrap();
-    assert!(white_queen.can_attack(black_queen));
+    assert!(white_queen.can_attack(&black_queen));
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn test_can_attack_on_first_diagonal() {
 fn test_can_attack_on_second_diagonal() {
     let white_queen = Queen::new((2,2)).unwrap();
     let black_queen = Queen::new((3,1)).unwrap();
-    assert!(white_queen.can_attack(black_queen));
+    assert!(white_queen.can_attack(&black_queen));
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn test_can_attack_on_second_diagonal() {
 fn test_can_attack_on_third_diagonal() {
     let white_queen = Queen::new((2,2)).unwrap();
     let black_queen = Queen::new((1,1)).unwrap();
-    assert!(white_queen.can_attack(black_queen));
+    assert!(white_queen.can_attack(&black_queen));
 }
 
 #[test]
@@ -77,5 +77,5 @@ fn test_can_attack_on_third_diagonal() {
 fn test_can_attack_on_fourth_diagonal() {
     let white_queen = Queen::new((2,2)).unwrap();
     let black_queen = Queen::new((5,5)).unwrap();
-    assert!(white_queen.can_attack(black_queen));
+    assert!(white_queen.can_attack(&black_queen));
 }


### PR DESCRIPTION
Transferring ownership to can_attack is poor design. It prevents you
from using the piece after the function has been called. A more Rust-ish
approach is to borrow.

I know this exercise is now available, so I'm not sure how easy it is to change the API now. But I sure hope we can!