### PR TITLE
dominoes: test singletons that can't be chained

### DIFF
--- a/exercises/dominoes/example.rs
+++ b/exercises/dominoes/example.rs
@@ -71,7 +71,7 @@ impl AvailabilityTable {
 pub fn chain(dominoes: &Vec<Domino>) -> Option<Vec<Domino>> {
     match dominoes.len() {
         0 => Some(vec!()),
-        1 => Some(vec!(dominoes[0])),
+        1 => if dominoes[0].0 == dominoes[0].1 { Some(vec![dominoes[0]]) } else { None },
         _ => {
             // First check if the total number of each amount of dots is even, if not it's not
             // possible to complete a cycle. This follows from that it's an Eulerian path.

--- a/exercises/dominoes/tests/dominoes.rs
+++ b/exercises/dominoes/tests/dominoes.rs
@@ -89,6 +89,13 @@ fn singleton_input_singleton_output() {
 
 #[test]
 #[ignore]
+fn singleton_that_cant_be_chained() {
+    let input = vec![(1, 2)];
+    assert_eq!(dominoes::chain(&input), None);
+}
+
+#[test]
+#[ignore]
 fn no_repeat_numbers() {
     let input = vec!((1, 2), (3, 1), (2, 3));
     assert_correct(&input);


### PR DESCRIPTION
Some solutions may automatically declare a singleton input to be valid
without checking it can actually be chained. Singletons still need to be
checked because a singleton (1, 1) can be chained with itself, but
(1, 2) can't. This adds a test for (1, 2). The test for (1, 1) already
existed.
    
The example solution needs to be corrected to address this as well.