### PR TITLE
dominoes: Rename invalid_input -> no_chains

### DIFF
--- a/exercises/dominoes/tests/dominoes.rs
+++ b/exercises/dominoes/tests/dominoes.rs
@@ -110,7 +110,7 @@ fn can_reverse_dominoes() {
 
 #[test]
 #[ignore]
-fn invalid_input() {
+fn no_chains() {
     let input = vec!((1, 2), (4, 1), (2, 3));
     assert_eq!(dominoes::chain(&input), None);
 }


### PR DESCRIPTION
The input is valid (it's a list of dominoes), it's just that it can't be
chained.

Closes #100