### PR TITLE
_test: rm tournament_setup.sh

### DIFF
--- a/_test/tournament_setup.sh
+++ b/_test/tournament_setup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-workdir="$1"
-cp tournament/input*.txt tournament/expected*.txt "$workdir"


### PR DESCRIPTION
At the time of e1acae44f0e82e64b3e6b257c2bc2f32cdad3acc, it was
necessary to use this script because tests were run in a temporary
working directory. Thus the convention of `{slug}_setup.sh` was born.

Then in fc69e6eba391f68700a7631fdba06c5f034f0c5e this became unnecessary
because instead the entire directory is getting copied. Not only that
but the convention of running `{slug}_setup.sh` was removed.

Since tournament_setup.sh is unnecessary and no longer being run, let's
remove it.

Closes #105.