### PR TITLE
travis: add a required build that fails on warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ rust:
   - stable
   - beta
   - nightly
+env:
+  - DENYWARNINGS=
+  - DENYWARNINGS=1
 matrix:
   allow_failures:
     - rust: nightly
+    - rust: beta
+      env: DENYWARNINGS=1

--- a/_test/check-exercises.sh
+++ b/_test/check-exercises.sh
@@ -35,10 +35,17 @@ for exercise in exercises/*/tests; do
 
         if [ -n "$DENYWARNINGS" ]; then
             sed -i -e '1i #![deny(warnings)]' src/lib.rs
-        fi
 
-        # Run the test and get the status
-        cargo test
+            # No-run mode so we see no test output.
+            # Quiet mode so we see no compile output
+            # (such as "Compiling"/"Downloading").
+            # Compiler errors will still be shown though.
+            # Both flags are necessary to keep things quiet.
+            cargo test --quiet --no-run
+        else
+            # Run the test and get the status
+            cargo test
+        fi
     )
 
     status=$?

--- a/_test/check-exercises.sh
+++ b/_test/check-exercises.sh
@@ -26,6 +26,10 @@ for exercise in exercises/*/tests; do
             sed -i '/\[ignore\]/d' $test
         done
 
+        if [ -n "$DENYWARNINGS" ]; then
+            sed -i -e '1i #![deny(warnings)]' src/lib.rs
+        fi
+
         # Run the test and get the status
         cargo test
     )

--- a/_test/check-exercises.sh
+++ b/_test/check-exercises.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
-set -e
+# In DENYWARNINGS mode, do not set -e so that we run all tests.
+# This allows us to see all warnings.
+if [ -z "$DENYWARNINGS" ]; then
+    set -e
+fi
+
 tmp=${TMPDIR:-/tmp/}
 mkdir "${tmp}exercises"
+
+exitcode=0
 
 # An exercise worth testing is defined here as any top level directory with
 # a 'tests' directory
@@ -38,7 +45,8 @@ for exercise in exercises/*/tests; do
 
     if [ $status -ne 0 ]
     then
-        echo "Failed";
-        return 1;
+        exitcode=1
     fi
 done
+
+exit $exitcode


### PR DESCRIPTION
I'm motivated because I've seen that I introduced warnings in #81 and
they were not caught.

Definitely open to discussion on whether it should be required! I don't
want this to be a nuisance, but I do generally like to avoid warnings.