### PR TITLE
rna-transcript: remove unused AsRef use

### DIFF
--- a/exercises/rna-transcription/example.rs
+++ b/exercises/rna-transcription/example.rs
@@ -1,5 +1,3 @@
-use std::convert::AsRef;
-
 #[derive(PartialEq, Eq, Debug)]
 pub struct RibonucleicAcid {
     nucleotides: String


### PR DESCRIPTION
The presence of the removed line causes a compile-time warning. This
warning was introduced in #81 with the removal of the AsRef tests for
the rna-transcript exercise.

To help us detect warnings in the future, #107 is opened as well.