### PR TITLE
Queen Attack: Replace tuple with ChessPosition

### DIFF
--- a/exercises/queen-attack/example.rs
+++ b/exercises/queen-attack/example.rs
@@ -1,78 +1,69 @@
-#[derive(Debug, PartialEq)]
-pub struct Queen { position: ChessPosition }
+pub struct Queen {
+    position: ChessPosition,
+}
+pub trait ChessPiece {
+    fn position(&self) -> &ChessPosition;
+    fn can_attack<T: ChessPiece>(&self, other: &T) -> bool;
+}
 
-impl Queen {
-    pub fn new(position: (i8, i8)) -> Result<Queen, ()> {
-        let position = ChessPosition::new(position);
-        if position.valid() {
-            Ok(Queen { position: position })
-        } else {
-            Err(())
-        }
+impl ChessPiece for Queen {
+    fn position(&self) -> &ChessPosition {
+        &self.position
     }
 
-    pub fn can_attack(&self, piece: &Queen) -> bool {
-        self.horizontal_from(&piece) ||
-            self.vertical_from(&piece) ||
-            self.diagonal_from(&piece)
-    }
-
-    fn horizontal_from(&self, piece: &Queen) -> bool {
-        self.rank() == piece.rank()
-    }
-
-    fn vertical_from(&self, piece: &Queen) -> bool {
-        self.file() == piece.file()
-    }
-
-    fn diagonal_from(&self, piece: &Queen) -> bool {
-        self.sum() == piece.sum() ||
-            self.difference() == piece.difference()
-    }
-
-    fn rank(&self) -> i8 {
-        self.position.rank()
-    }
-
-    fn file(&self) -> i8 {
-        self.position.file()
-    }
-
-    fn sum(&self) -> i8 {
-        self.position.sum()
-    }
-
-    fn difference(&self) -> i8 {
-        self.position.difference()
+    fn can_attack<T: ChessPiece>(&self, piece: &T) -> bool {
+        self.position.horizontal_from(&piece.position()) ||
+        self.position.vertical_from(&piece.position()) ||
+        self.position.diagonal_from(&piece.position())
     }
 }
 
-#[derive(Debug, PartialEq)]
-struct ChessPosition { coordinates: (i8, i8) }
+impl Queen {
+    pub fn new(position: ChessPosition) -> Queen {
+        Queen { position: position }
+    }
+}
+
+pub struct ChessPosition {
+    pub rank: i8,
+    pub file: i8,
+}
 
 impl ChessPosition {
-    fn new(coordinates: (i8, i8)) -> ChessPosition {
-        ChessPosition {coordinates: coordinates}
+    pub fn new(rank: i8, file: i8) -> Result<ChessPosition, String> {
+        let position = ChessPosition {
+            rank: rank,
+            file: file,
+        };
+
+        if position.is_valid() {
+            Ok(position)
+        } else {
+            Err(String::from("Invalid Position"))
+        }
     }
 
-    fn valid(&self) -> bool {
-        (self.rank() >= 0 && self.rank() <= 7) &&
-        (self.file() >= 0 && self.file() <= 7)
+    fn is_valid(&self) -> bool {
+        self.rank >= 0 && self.rank <= 7 && self.file >= 0 && self.file <= 7
     }
 
-    fn rank(&self) -> i8 {
-        self.coordinates.0
+    fn horizontal_from(&self, other: &ChessPosition) -> bool {
+        self.rank == other.rank
     }
 
-    fn file(&self) -> i8 {
-        self.coordinates.1
+    fn vertical_from(&self, other: &ChessPosition) -> bool {
+        self.file == other.file
+    }
+
+    fn diagonal_from(&self, other: &ChessPosition) -> bool {
+        self.sum() == other.sum() || self.difference() == other.difference()
     }
 
     fn sum(&self) -> i8 {
-        self.rank() + self.file()
+        self.rank + self.file
     }
 
     fn difference(&self) -> i8 {
-        self.rank() - self.file()
+        self.rank - self.file
     }
 }

--- a/exercises/queen-attack/tests/queen-attack.rs
+++ b/exercises/queen-attack/tests/queen-attack.rs
@@ -3,79 +3,84 @@ extern crate queen_attack;
 use queen_attack::*;
 
 #[test]
-fn test_queen_creation_with_valid_position() {
-    let white_queen = Queen::new((2,4));
-    assert!(white_queen.is_ok());
+fn chess_position_on_the_board_is_ok() {
+    assert!(ChessPosition::new(2, 4).is_ok());
 }
 
 #[test]
 #[ignore]
-fn test_queen_creation_with_incorrect_positions() {
-    let white_queen = Queen::new((-1,2));
-    assert!(white_queen.is_err());
-
-    let white_queen = Queen::new((8,2));
-    assert!(white_queen.is_err());
-
-    let white_queen = Queen::new((5,-1));
-    assert!(white_queen.is_err());
-
-    let white_queen = Queen::new((5,8));
-    assert!(white_queen.is_err());
+fn chess_position_off_the_board_is_err() {
+    assert!(ChessPosition::new(-1, 2).is_err());
+    assert!(ChessPosition::new(8, 2).is_err());
+    assert!(ChessPosition::new(5, -1).is_err());
+    assert!(ChessPosition::new(5, 8).is_err());
 }
 
 #[test]
 #[ignore]
-fn test_can_not_attack() {
-    let white_queen = Queen::new((2,4)).unwrap();
-    let black_queen = Queen::new((6,6)).unwrap();
-    assert_eq!(false, white_queen.can_attack(&black_queen));
+fn queen_is_created_with_a_ok_position() {
+    Queen::new(ChessPosition::new(2, 4).unwrap());
 }
 
 #[test]
 #[ignore]
-fn test_can_attack_on_same_rank() {
-    let white_queen = Queen::new((2,4)).unwrap();
-    let black_queen = Queen::new((2,6)).unwrap();
+#[should_panic(expected = "Invalid Position")]
+fn queen_panics_with_err_position() {
+    Queen::new(ChessPosition::new(-1, 4).unwrap());
+}
+
+#[test]
+#[ignore]
+fn queens_that_can_not_attack() {
+    let white_queen = Queen::new(ChessPosition::new(2, 4).unwrap());
+    let black_queen = Queen::new(ChessPosition::new(6, 6).unwrap());
+    assert!(!white_queen.can_attack(&black_queen));
+}
+
+#[test]
+#[ignore]
+fn queens_on_the_same_rank_can_attack() {
+    let white_queen = Queen::new(ChessPosition::new(2, 4).unwrap());
+    let black_queen = Queen::new(ChessPosition::new(2, 6).unwrap());
     assert!(white_queen.can_attack(&black_queen));
 }
 
 #[test]
 #[ignore]
-fn test_can_attack_on_same_file() {
-    let white_queen = Queen::new((4,5)).unwrap();
-    let black_queen = Queen::new((3,5)).unwrap();
+fn queens_on_the_same_file_can_attack() {
+    let white_queen = Queen::new(ChessPosition::new(4, 5).unwrap());
+    let black_queen = Queen::new(ChessPosition::new(3, 5).unwrap());
     assert!(white_queen.can_attack(&black_queen));
 }
 
 #[test]
 #[ignore]
-fn test_can_attack_on_first_diagonal() {
-    let white_queen = Queen::new((2,2)).unwrap();
-    let black_queen = Queen::new((0,4)).unwrap();
+fn queens_on_the_same_diagonal_can_attack_one() {
+    let white_queen = Queen::new(ChessPosition::new(2, 2).unwrap());
+    let black_queen = Queen::new(ChessPosition::new(0, 4).unwrap());
     assert!(white_queen.can_attack(&black_queen));
 }
 
 #[test]
 #[ignore]
-fn test_can_attack_on_second_diagonal() {
-    let white_queen = Queen::new((2,2)).unwrap();
-    let black_queen = Queen::new((3,1)).unwrap();
+fn queens_on_the_same_diagonal_can_attack_two() {
+    let white_queen = Queen::new(ChessPosition::new(2, 2).unwrap());
+    let black_queen = Queen::new(ChessPosition::new(3, 1).unwrap());
     assert!(white_queen.can_attack(&black_queen));
 }
 
 #[test]
 #[ignore]
-fn test_can_attack_on_third_diagonal() {
-    let white_queen = Queen::new((2,2)).unwrap();
-    let black_queen = Queen::new((1,1)).unwrap();
+fn queens_on_the_same_diagonal_can_attack_three() {
+    let white_queen = Queen::new(ChessPosition::new(2, 2).unwrap());
+    let black_queen = Queen::new(ChessPosition::new(1, 1).unwrap());
     assert!(white_queen.can_attack(&black_queen));
 }
 
 #[test]
 #[ignore]
-fn test_can_attack_on_fourth_diagonal() {
-    let white_queen = Queen::new((2,2)).unwrap();
-    let black_queen = Queen::new((5,5)).unwrap();
+fn queens_on_the_same_diagonal_can_attack_four() {
+    let white_queen = Queen::new(ChessPosition::new(2, 2).unwrap());
+    let black_queen = Queen::new(ChessPosition::new(5, 5).unwrap());
     assert!(white_queen.can_attack(&black_queen));
 }


### PR DESCRIPTION
Fixes #118

`Queen::new` now expects a `ChessPosition` instead of a tuple. `ChessPosition::new` returns a Result, indicating if the position is valid or not.

I've added a few tests at the start to capture the behavior of `ChessPosition`.  The tests of Queen have their API usage updated, and have been renamed for readability.