### PR TITLE
Update Custom Set to follow new standard suite

### DIFF
--- a/exercises/custom-set/example.rs
+++ b/exercises/custom-set/example.rs
@@ -25,20 +25,12 @@ impl<T: Ord + Clone> CustomSet<T> {
         }
     }
 
-    pub fn delete(&mut self, element: &T) {
-        self.collection.retain(|x| x != element)
-    }
-
     pub fn contains(&self, other: &T) -> bool {
         self.collection.contains(other)
     }
 
     pub fn is_empty(&self) -> bool {
         self.collection.is_empty()
-    }
-
-    pub fn size(&self) -> usize {
-        self.collection.len()
     }
 
     pub fn is_subset(&self, other: &Self) -> bool {
@@ -70,15 +62,6 @@ impl<T: Ord + Clone> CustomSet<T> {
                            .iter()
                            .cloned()
                            .filter(|c| !other.contains(c))
-                           .collect())
-    }
-
-    pub fn symmetric_difference(&self, other: &Self) -> CustomSet<T> {
-        CustomSet::new(self.difference(other)
-                           .collection
-                           .iter()
-                           .cloned()
-                           .chain(other.difference(self).collection.iter().cloned())
                            .collect())
     }
 }

--- a/exercises/custom-set/tests/custom-set.rs
+++ b/exercises/custom-set/tests/custom-set.rs
@@ -3,66 +3,37 @@ extern crate custom_set as set;
 use set::*;
 
 #[test]
-fn empty_sets_are_equal() {
-    let set1: CustomSet<()> = CustomSet::new(vec![]);
-    let set2: CustomSet<()> = CustomSet::new(vec![]);
-    assert_eq!(set1, set2);
+fn sets_with_no_elements_are_empty() {
+    let set: CustomSet<()> = CustomSet::new(vec![]);
+    assert!(set.is_empty());
 }
 
 #[test]
 #[ignore]
-fn sets_with_same_single_element_are_equal() {
-    let set1 = CustomSet::new(vec![1]);
-    let set2 = CustomSet::new(vec![1]);
-    assert_eq!(set1, set2);
+fn sets_with_elements_are_not_empty() {
+    let set = CustomSet::new(vec![1]);
+    assert!(!set.is_empty());
 }
 
 #[test]
 #[ignore]
-fn duplicates_do_not_matter() {
-    let set1 = CustomSet::new(vec![1, 1]);
-    let set2 = CustomSet::new(vec![1]);
-    assert_eq!(set1, set2);
+fn nothing_is_contained_in_an_empty_set() {
+    let set = CustomSet::new(vec![]);
+    assert!(!set.contains(&1));
 }
 
 #[test]
 #[ignore]
-fn order_does_not_matter() {
-    let set1 = CustomSet::new(vec![1, 3]);
-    let set2 = CustomSet::new(vec![3, 1]);
-    assert_eq!(set1, set2);
+fn true_when_the_element_is_in_the_set() {
+    let set = CustomSet::new(vec![1, 2, 3]);
+    assert!(set.contains(&1));
 }
 
 #[test]
 #[ignore]
-fn different_sets_are_unequal() {
-    let set1 = CustomSet::new(vec![1, 2, 3]);
-    let set2 = CustomSet::new(vec![3, 4, 5]);
-    assert!(set1 != set2);
-}
-
-#[test]
-#[ignore]
-fn empty_set_is_not_equal_to_a_non_empty_set() {
-    let set1 = CustomSet::new(vec![]);
-    let set2 = CustomSet::new(vec![1, 2, 3]);
-    assert!(set1 != set2);
-}
-
-#[test]
-#[ignore]
-fn non_empty_set_is_not_equal_to_a_empty_set() {
-    let set1 = CustomSet::new(vec![1, 2, 3]);
-    let set2 = CustomSet::new(vec![]);
-    assert!(set1 != set2);
-}
-
-#[test]
-#[ignore]
-fn all_elements_must_be_equal_for_sets_to_be_equal() {
-    let set1 = CustomSet::new(vec![1, 2, 3, 4]);
-    let set2 = CustomSet::new(vec![2, 3, 4, 5]);
-    assert!(set1 != set2);
+fn false_when_the_element_is_not_in_the_set() {
+    let set = CustomSet::new(vec![1, 2, 3]);
+    assert!(!set.contains(&4));
 }
 
 #[test]
@@ -91,99 +62,6 @@ fn add_existing_element() {
 
 #[test]
 #[ignore]
-fn delete_an_existing_element() {
-    let mut set = CustomSet::new(vec![3, 2, 1]);
-    set.delete(&2);
-    assert_eq!(set, CustomSet::new(vec![1, 3]));
-}
-
-#[test]
-#[ignore]
-fn delete_an_nonexistent_element() {
-    let mut set = CustomSet::new(vec![3, 2, 1]);
-    set.delete(&4);
-    assert_eq!(set, CustomSet::new(vec![1, 2, 3]));
-}
-
-#[test]
-#[ignore]
-fn is_empty_without_elements() {
-    let set: CustomSet<()> = CustomSet::new(vec![]);
-    assert!(set.is_empty());
-}
-
-#[test]
-#[ignore]
-fn is_not_empty_with_element() {
-    let set = CustomSet::new(vec![1]);
-    assert!(!set.is_empty());
-}
-
-#[test]
-#[ignore]
-fn is_not_empty_with_elements() {
-    let set = CustomSet::new(vec![1, 2, 3, 2]);
-    assert!(!set.is_empty());
-}
-
-#[test]
-#[ignore]
-fn empty_set_has_size_0() {
-    let set: CustomSet<()> = CustomSet::new(vec![]);
-    assert_eq!(set.size(), 0);
-}
-
-#[test]
-#[ignore]
-fn non_empty_set_has_size_of_element_count() {
-    let set = CustomSet::new(vec![1, 2, 4]);
-    assert_eq!(set.size(), 3);
-}
-
-#[test]
-#[ignore]
-fn duplicate_elements_are_not_counted() {
-    let set = CustomSet::new(vec![1, 2, 3, 2]);
-    assert_eq!(set.size(), 3);
-}
-
-#[test]
-#[ignore]
-fn empty_set_does_not_contain_element() {
-    let set = CustomSet::new(vec![]);
-    assert!(!set.contains(&1));
-}
-
-#[test]
-#[ignore]
-fn contains_element_1_in_set() {
-    let set = CustomSet::new(vec![1, 2, 3, 2]);
-    assert!(set.contains(&1));
-}
-
-#[test]
-#[ignore]
-fn contains_element_2_in_set() {
-    let set = CustomSet::new(vec![1, 2, 3, 2]);
-    assert!(set.contains(&2));
-}
-
-#[test]
-#[ignore]
-fn contains_element_3_in_set() {
-    let set = CustomSet::new(vec![1, 2, 3, 2]);
-    assert!(set.contains(&3));
-}
-
-#[test]
-#[ignore]
-fn does_not_contain_element_4_in_set() {
-    let set = CustomSet::new(vec![1, 2, 3, 2]);
-    assert!(!set.contains(&4));
-}
-
-#[test]
-#[ignore]
 fn empty_sets_are_subsets_of_each_other() {
     let set1: CustomSet<()> = CustomSet::new(vec![]);
     let set2: CustomSet<()> = CustomSet::new(vec![]);
@@ -202,9 +80,9 @@ fn empty_set_is_subset_of_non_empty_set() {
 #[test]
 #[ignore]
 fn non_empty_set_is_not_subset_of_empty_set() {
-    let set1 = CustomSet::new(vec![]);
-    let set2 = CustomSet::new(vec![1]);
-    assert!(!set2.is_subset(&set1));
+    let set1 = CustomSet::new(vec![1]);
+    let set2 = CustomSet::new(vec![]);
+    assert!(!set1.is_subset(&set2));
 }
 
 #[test]
@@ -220,7 +98,7 @@ fn sets_with_same_elements_are_subsets() {
 #[ignore]
 fn set_contained_in_other_set_is_a_subset() {
     let set1 = CustomSet::new(vec![1, 2, 3]);
-    let set2 = CustomSet::new(vec![1, 2, 3, 4]);
+    let set2 = CustomSet::new(vec![4, 1, 2, 3]);
     assert!(set1.is_subset(&set2));
 }
 
@@ -229,22 +107,6 @@ fn set_contained_in_other_set_is_a_subset() {
 fn set_not_contained_in_other_set_is_not_a_subset_one() {
     let set1 = CustomSet::new(vec![1, 2, 3]);
     let set2 = CustomSet::new(vec![4, 1, 3]);
-    assert!(!set1.is_subset(&set2));
-}
-
-#[test]
-#[ignore]
-fn set_not_contained_in_other_set_is_not_a_subset_two() {
-    let set1 = CustomSet::new(vec![1, 2, 3, 4, 5]);
-    let set2 = CustomSet::new(vec![2, 3, 4]);
-    assert!(!set1.is_subset(&set2));
-}
-
-#[test]
-#[ignore]
-fn set_not_contained_in_other_set_is_not_a_subset_three() {
-    let set1 = CustomSet::new(vec![1, 2, 3, 11]);
-    let set2 = CustomSet::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     assert!(!set1.is_subset(&set2));
 }
 
@@ -310,114 +172,27 @@ fn intersecting_empty_set_with_non_empty_returns_empty_set() {
 #[test]
 #[ignore]
 fn intersecting_non_empty_set_with_empty_returns_empty_set() {
-    let set1 = CustomSet::new(vec![3, 2, 5]);
+    let set1 = CustomSet::new(vec![1, 2, 3, 4]);
     let set2 = CustomSet::new(vec![]);
     assert_eq!(set1.intersection(&set2), CustomSet::new(vec![]));
 }
 
 #[test]
 #[ignore]
-fn intersecting_equal_sets_returns_the_same_set() {
-    let set1 = CustomSet::new(vec![3]);
-    let set2 = CustomSet::new(vec![3]);
-    assert_eq!(set1.intersection(&set2), CustomSet::new(vec![3]));
-}
-
-#[test]
-#[ignore]
-fn intersecting_returns_shared_elements_one() {
-    let set1 = CustomSet::new(vec![1, 2, 3]);
-    let set2 = CustomSet::new(vec![3, 5, 4]);
-    assert_eq!(set1.intersection(&set2), CustomSet::new(vec![3]));
-}
-
-#[test]
-#[ignore]
-fn intersecting_returns_shared_elements_two() {
-    let set1 = CustomSet::new(vec![1, 2, 3, 4]);
-    let set2 = CustomSet::new(vec![3, 5, 4]);
-    assert_eq!(set1.intersection(&set2), CustomSet::new(vec![3, 4]));
-}
-
-#[test]
-#[ignore]
-fn intersecting_returns_shared_elements_three() {
-    let set1 = CustomSet::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    let set2 = CustomSet::new(vec![5, 6, 7, 8, 9, 10]);
-    assert_eq!(set1.intersection(&set2),
-               CustomSet::new(vec![5, 6, 7, 8, 9, 10]));
-}
-
-#[test]
-#[ignore]
-fn intersecting_no_shared_elements_returns_empty_set() {
+fn intersection_of_two_sets_with_no_shared_elements_is_an_empty_set() {
     let set1 = CustomSet::new(vec![1, 2, 3]);
     let set2 = CustomSet::new(vec![4, 5, 6]);
     assert_eq!(set1.intersection(&set2), CustomSet::new(vec![]));
+    assert_eq!(set2.intersection(&set1), CustomSet::new(vec![]));
 }
 
 #[test]
 #[ignore]
-fn union_of_two_empty_sets_is_empty_set() {
-    let set1: CustomSet<()> = CustomSet::new(vec![]);
-    let set2: CustomSet<()> = CustomSet::new(vec![]);
-    assert_eq!(set1.union(&set2), CustomSet::new(vec![]));
-}
-
-#[test]
-#[ignore]
-fn union_of_empty_set_and_non_empty_set_is_all_elements() {
-    let set1 = CustomSet::new(vec![]);
-    let set2 = CustomSet::new(vec![2]);
-    assert_eq!(set1.union(&set2), CustomSet::new(vec![2]));
-}
-
-#[test]
-#[ignore]
-fn union_of_empty_set_and_non_empty_set_is_all_elements_two() {
-    let set1 = CustomSet::new(vec![]);
-    let set2 = CustomSet::new(vec![3, 2, 5]);
-    assert_eq!(set1.union(&set2), CustomSet::new(vec![3, 2, 5]));
-}
-
-#[test]
-#[ignore]
-fn union_of_non_empty_set_and_empty_set_is_all_elements() {
-    let set1 = CustomSet::new(vec![1, 3]);
-    let set2 = CustomSet::new(vec![]);
-    assert_eq!(set1.union(&set2), CustomSet::new(vec![1, 3]));
-}
-
-#[test]
-#[ignore]
-fn union_of_two_sets_with_same_elements_contains_no_duplicates() {
-    let set1 = CustomSet::new(vec![1, 3]);
-    let set2 = CustomSet::new(vec![3, 1]);
-    assert_eq!(set1.union(&set2), CustomSet::new(vec![1, 3]));
-}
-
-#[test]
-#[ignore]
-fn union_of_two_non_empty_sets_contains_all_unique_elements_one() {
-    let set1 = CustomSet::new(vec![1, 3]);
-    let set2 = CustomSet::new(vec![2]);
-    assert_eq!(set1.union(&set2), CustomSet::new(vec![1, 2, 3]));
-}
-
-#[test]
-#[ignore]
-fn union_of_two_non_empty_sets_contains_all_unique_elements_two() {
-    let set1 = CustomSet::new(vec![1, 3]);
-    let set2 = CustomSet::new(vec![2, 3]);
-    assert_eq!(set1.union(&set2), CustomSet::new(vec![1, 2, 3]));
-}
-
-#[test]
-#[ignore]
-fn union_of_two_non_empty_sets_contains_all_unique_elements_three() {
+fn intersection_of_two_sets_with_shared_elements_is_a_set_of_the_shared_elements() {
     let set1 = CustomSet::new(vec![1, 2, 3, 4]);
     let set2 = CustomSet::new(vec![3, 2, 5]);
-    assert_eq!(set1.union(&set2), CustomSet::new(vec![1, 2, 3, 4, 5]));
+    assert_eq!(set1.intersection(&set2), CustomSet::new(vec![2, 3]));
+    assert_eq!(set2.intersection(&set1), CustomSet::new(vec![2, 3]));
 }
 
 #[test]
@@ -446,68 +221,80 @@ fn difference_of_a_non_empty_set_and_empty_set_is_the_non_empty_set() {
 
 #[test]
 #[ignore]
-fn difference_of_two_non_empty_sets_are_elements_only_in_first_set_one() {
-    let set1 = CustomSet::new(vec![1, 2, 3]);
-    let set2 = CustomSet::new(vec![4]);
-    assert_eq!(set1.difference(&set2), CustomSet::new(vec![1, 2, 3]));
-}
-
-#[test]
-#[ignore]
-fn difference_of_two_non_empty_sets_are_elements_only_in_first_set_two() {
-    let set1 = CustomSet::new(vec![1, 2, 3]);
-    let set2 = CustomSet::new(vec![4, 2]);
+fn difference_of_two_non_empty_sets_is_elements_only_in_first_set_one() {
+    let set1 = CustomSet::new(vec![3, 2, 1]);
+    let set2 = CustomSet::new(vec![2, 4]);
     assert_eq!(set1.difference(&set2), CustomSet::new(vec![1, 3]));
 }
 
 #[test]
 #[ignore]
-fn difference_of_two_non_empty_sets_are_elements_only_in_first_set_three() {
-    let set1 = CustomSet::new(vec![1, 2, 3, 4]);
-    let set2 = CustomSet::new(vec![3, 2, 5]);
-    assert_eq!(set1.difference(&set2), CustomSet::new(vec![1, 4]));
-}
-
-#[test]
-#[ignore]
-fn symmetric_difference_of_two_empty_sets_is_an_empty_set() {
+fn empty_sets_are_equal() {
     let set1: CustomSet<()> = CustomSet::new(vec![]);
     let set2: CustomSet<()> = CustomSet::new(vec![]);
-    assert_eq!(set1.symmetric_difference(&set2), CustomSet::new(vec![]));
+    assert_eq!(set1, set2);
 }
 
 #[test]
 #[ignore]
-fn symmetric_difference_of_empty_and_non_empty_set_is_the_non_empty_set() {
+fn empty_set_is_not_equal_to_a_non_empty_set() {
     let set1 = CustomSet::new(vec![]);
-    let set2 = CustomSet::new(vec![3, 2, 5]);
-    assert_eq!(set1.symmetric_difference(&set2),
-               CustomSet::new(vec![3, 2, 5]));
+    let set2 = CustomSet::new(vec![1, 2, 3]);
+    assert!(set1 != set2);
 }
 
 #[test]
 #[ignore]
-fn symmetric_difference_of_non_empty_and_empty_set_is_the_non_empty_set() {
-    let set1 = CustomSet::new(vec![]);
-    let set2 = CustomSet::new(vec![1, 2, 3, 4]);
-    assert_eq!(set1.symmetric_difference(&set2),
-               CustomSet::new(vec![1, 2, 3, 4]));
-}
-
-#[test]
-#[ignore]
-fn symmetric_difference_of_two_sets_is_unshared_elements_one() {
+fn non_empty_set_is_not_equal_to_an_empty_set() {
     let set1 = CustomSet::new(vec![1, 2, 3]);
-    let set2 = CustomSet::new(vec![4]);
-    assert_eq!(set1.symmetric_difference(&set2),
-               CustomSet::new(vec![1, 2, 3, 4]));
+    let set2 = CustomSet::new(vec![]);
+    assert!(set1 != set2);
 }
 
 #[test]
 #[ignore]
-fn symmetric_difference_of_two_sets_is_unshared_elements_two() {
-    let set1 = CustomSet::new(vec![3, 2, 1]);
-    let set2 = CustomSet::new(vec![2, 4]);
-    assert_eq!(set1.symmetric_difference(&set2),
-               CustomSet::new(vec![1, 3, 4]));
+fn sets_with_the_same_elements_are_equal() {
+    let set1 = CustomSet::new(vec![1, 2]);
+    let set2 = CustomSet::new(vec![2, 1]);
+    assert_eq!(set1, set2);
+}
+
+#[test]
+#[ignore]
+fn sets_with_different_elements_are_not_equal() {
+    let set1 = CustomSet::new(vec![1, 2, 3]);
+    let set2 = CustomSet::new(vec![2, 1, 4]);
+    assert!(set1 != set2);
+}
+
+#[test]
+#[ignore]
+fn union_of_two_empty_sets_is_empty_set() {
+    let set1: CustomSet<()> = CustomSet::new(vec![]);
+    let set2: CustomSet<()> = CustomSet::new(vec![]);
+    assert_eq!(set1.union(&set2), CustomSet::new(vec![]));
+}
+
+#[test]
+#[ignore]
+fn union_of_empty_set_and_non_empty_set_is_all_elements() {
+    let set1 = CustomSet::new(vec![]);
+    let set2 = CustomSet::new(vec![2]);
+    assert_eq!(set1.union(&set2), CustomSet::new(vec![2]));
+}
+
+#[test]
+#[ignore]
+fn union_of_non_empty_set_and_empty_set_is_the_non_empty_set() {
+    let set1 = CustomSet::new(vec![1, 3]);
+    let set2 = CustomSet::new(vec![]);
+    assert_eq!(set1.union(&set2), CustomSet::new(vec![1, 3]));
+}
+
+#[test]
+#[ignore]
+fn union_of_non_empty_sets_contains_all_unique_elements() {
+    let set1 = CustomSet::new(vec![1, 3]);
+    let set2 = CustomSet::new(vec![2, 3]);
+    assert_eq!(set1.union(&set2), CustomSet::new(vec![3, 2, 1]));
 }


### PR DESCRIPTION
Details about the updated test suite are at
https://github.com/exercism/x-common/pull/232

This commit brings our tests in line with the new standard and removes
now-unnecessary code from the example solution