### PR TITLE
Add Scrabble Score

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,6 +15,7 @@
     "rna-transcription",
     "nucleotide-count",
     "nucleotide-codons",
+    "scrabble-score",
     "roman-numerals",
     "robot-name",
     "etl",

--- a/exercises/scrabble-score/Cargo.lock
+++ b/exercises/scrabble-score/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "scrabble-score"
+version = "0.0.0"
+

--- a/exercises/scrabble-score/Cargo.toml
+++ b/exercises/scrabble-score/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "scrabble-score"
+version = "0.0.0"

--- a/exercises/scrabble-score/example.rs
+++ b/exercises/scrabble-score/example.rs
@@ -1,0 +1,40 @@
+use std::collections::HashMap;
+
+pub fn score(word: &str) -> u16 {
+    let values = dictionary();
+    word.to_lowercase()
+        .chars()
+        .map(|c| values.get(&c).clone())
+        .fold(0, |score, v| score + v.unwrap_or(&0))
+}
+
+fn dictionary() -> HashMap<char, u16> {
+    let mut values = HashMap::new();
+    values.insert('a', 1);
+    values.insert('b', 3);
+    values.insert('c', 3);
+    values.insert('d', 2);
+    values.insert('e', 1);
+    values.insert('f', 4);
+    values.insert('g', 2);
+    values.insert('h', 4);
+    values.insert('i', 1);
+    values.insert('j', 8);
+    values.insert('k', 5);
+    values.insert('l', 1);
+    values.insert('m', 3);
+    values.insert('n', 1);
+    values.insert('o', 1);
+    values.insert('p', 3);
+    values.insert('q', 10);
+    values.insert('r', 1);
+    values.insert('s', 1);
+    values.insert('t', 1);
+    values.insert('u', 1);
+    values.insert('v', 4);
+    values.insert('w', 4);
+    values.insert('x', 8);
+    values.insert('y', 4);
+    values.insert('z', 10);
+    values
+}

--- a/exercises/scrabble-score/tests/scrabble-score.rs
+++ b/exercises/scrabble-score/tests/scrabble-score.rs
@@ -1,0 +1,63 @@
+extern crate scrabble_score;
+
+use scrabble_score::*;
+
+#[test]
+fn a_is_worth_one_point() {
+    assert_eq!(score("a"), 1);
+}
+
+#[test]
+#[ignore]
+fn scoring_is_case_insensitive() {
+    assert_eq!(score("A"), 1);
+}
+
+#[test]
+#[ignore]
+fn f_is_worth_four() {
+    assert_eq!(score("f"), 4);
+}
+
+#[test]
+#[ignore]
+fn two_one_point_letters_make_a_two_point_word() {
+    assert_eq!(score("at"), 2);
+}
+
+#[test]
+#[ignore]
+fn three_letter_word() {
+    assert_eq!(score("zoo"), 12);
+}
+
+#[test]
+#[ignore]
+fn medium_word() {
+    assert_eq!(score("street"), 6);
+}
+
+#[test]
+#[ignore]
+fn longer_words_with_valuable_letters() {
+    assert_eq!(score("quirky"), 22);
+}
+
+#[test]
+#[ignore]
+fn long_mixed_case_word() {
+    assert_eq!(score("OxyphenButazone"), 41);
+}
+
+#[test]
+#[ignore]
+fn non_english_scrabble_letters_do_not_score() {
+    assert_eq!(score("pinata"), 8);
+    assert_eq!(score("piñata"), 7);
+}
+
+#[test]
+#[ignore]
+fn empty_words_are_worth_zero() {
+    assert_eq!(score(""), 0);
+}


### PR DESCRIPTION
Implements the Scrabble Score exercise.

As of right now there is no official test suite for Scrabble Score. There is a PR (https://github.com/exercism/x-common/pull/161), but it is not yet merged.

I am following the test suite in that PR, with one exception. I thought it was likely that a common naive implementation would be to map through the chars, find the score and then simply unwrap the value. Like this:

```rust
word.chars().map(|c| values.get(&c).fold(0, |sum, v| sum + v.unwrap())
```

So I have added a test that uses a non-English character that will cause this implementation to panic.

I've put this exercise between the Nucleotides and Roman Numerals, figuring that it did similar character iteration and value mapping.

My example implementation probably leaves a lot to be desired. I wanted to make the values hash a static, but you can't do that with a hash.

[Lazy Static](http://rust-lang-nursery.github.io/lazy-static.rs/lazy_static/index.html) does let you do this, but I'm not going to require a crate in my example.