### PR TITLE
Ignore extraneous Rust files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.swp
-*.beam
 *.bk
 .DS_Store
 **/src

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.swp
 *.beam
+*.bk
 .DS_Store
+**/src
+**/target
 tmp
 bin/configlet
 bin/configlet.exe


### PR DESCRIPTION
Just so that we don't accidentally commit backup files, compiled code or
source files.