### PR TITLE
Check that result contains expected allergens

### DIFF
--- a/exercises/allergies/tests/allergies.rs
+++ b/exercises/allergies/tests/allergies.rs
@@ -40,10 +40,14 @@ fn test_just_to_peanuts() {
 #[test]
 #[ignore]
 fn test_allergic_to_everything() {
-    assert_eq!(vec![Allergen::Eggs, Allergen::Peanuts, Allergen::Shellfish,
-                    Allergen::Strawberries, Allergen::Tomatoes, Allergen::Chocolate,
-                    Allergen::Pollen, Allergen::Cats],
-        Allergies::new(255).allergies());
+    let all = vec![Allergen::Eggs, Allergen::Peanuts, Allergen::Shellfish,
+                   Allergen::Strawberries, Allergen::Tomatoes,
+                   Allergen::Chocolate, Allergen::Pollen, Allergen::Cats];
+    let allergies = Allergies::new(255).allergies();
+
+    for allergy in &all {
+        assert!(allergies.contains(&allergy));
+    }
 }
 
 #[test]

--- a/exercises/allergies/tests/allergies.rs
+++ b/exercises/allergies/tests/allergies.rs
@@ -45,6 +45,8 @@ fn test_allergic_to_everything() {
                    Allergen::Chocolate, Allergen::Pollen, Allergen::Cats];
     let allergies = Allergies::new(255).allergies();
 
+    assert_eq!(allergies.len(), all.len());
+
     for allergy in &all {
         assert!(allergies.contains(&allergy));
     }


### PR DESCRIPTION
Fixes #130

Testing for all allergies would fail if the allergens weren't in the
same order as the test vector.

This checks that the result contains all the expected allergens rather
than expecting the result and test vector to be equal.