### PR TITLE
Point students to the xrust Repository

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -20,5 +20,11 @@ if you wish.
 Make sure to read the [Crates and Modules](https://doc.rust-lang.org/stable/book/crates-and-modules.html) chapter if you
 haven't already, it will help you with organizing your files.
 
+## Feedback, Issues, Pull Requests
+
+The [exercism/xrust](https://github.com/exercism/xrust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the [rust track team](https://github.com/orgs/exercism/teams/rust) are happy to help!
+
+If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md).
+
 [help-page]: http://exercism.io/languages/rust
 [crates-and-modules]: http://doc.rust-lang.org/stable/book/crates-and-modules.html


### PR DESCRIPTION
I was trying to figure out how how I even found this repository. I think
I stumbled into it via the contributing guide on the main exercism repo.

I thought it would be nice to have each exercise contain a pointer to
the repo, so that students can easily see where all this code comes
from.