### PR TITLE
Update Allergies tests to canonical set

### DIFF
--- a/exercises/allergies/tests/allergies.rs
+++ b/exercises/allergies/tests/allergies.rs
@@ -2,8 +2,16 @@ extern crate allergies;
 
 use allergies::*;
 
+fn compare_allergy_vectors(expected: &Vec<Allergen>, actual: &Vec<Allergen>) {
+    assert_eq!(actual.len(), expected.len());
+
+    for allergy in expected {
+        assert!(actual.contains(&allergy));
+    }
+}
+
 #[test]
-fn test_no_allergies_means_not_allergic() {
+fn is_not_allergic_to_anything() {
     let allergies = Allergies::new(0);
     assert_eq!(false, allergies.is_allergic_to(&Allergen::Peanuts));
     assert_eq!(false, allergies.is_allergic_to(&Allergen::Cats));
@@ -12,13 +20,13 @@ fn test_no_allergies_means_not_allergic() {
 
 #[test]
 #[ignore]
-fn test_is_allergic_to_eggs() {
+fn is_allergic_to_eggs() {
     assert_eq!(true, Allergies::new(1).is_allergic_to(&Allergen::Eggs));
 }
 
 #[test]
 #[ignore]
-fn test_has_the_right_allergies() {
+fn is_allergic_to_egg_shellfish_and_strawberries() {
     let allergies = Allergies::new(5);
     assert_eq!(true, allergies.is_allergic_to(&Allergen::Eggs));
     assert_eq!(true, allergies.is_allergic_to(&Allergen::Shellfish));
@@ -27,33 +35,98 @@ fn test_has_the_right_allergies() {
 
 #[test]
 #[ignore]
-fn test_no_allergies_at_all() {
-    assert_eq!(Vec::<Allergen>::new(), Allergies::new(0).allergies());
+fn no_allergies_at_all() {
+    let expected: Vec<Allergen> = Vec::new();
+    let allergies = Allergies::new(0).allergies();
+
+    compare_allergy_vectors(&expected, &allergies);
 }
 
 #[test]
 #[ignore]
-fn test_just_to_peanuts() {
-    assert_eq!(vec![Allergen::Peanuts], Allergies::new(2).allergies());
+fn allergic_to_just_eggs() {
+    let expected = vec![Allergen::Eggs];
+    let allergies = Allergies::new(1).allergies();
+
+    compare_allergy_vectors(&expected, &allergies);
 }
 
 #[test]
 #[ignore]
-fn test_allergic_to_everything() {
-    let all = vec![Allergen::Eggs, Allergen::Peanuts, Allergen::Shellfish,
-                   Allergen::Strawberries, Allergen::Tomatoes,
-                   Allergen::Chocolate, Allergen::Pollen, Allergen::Cats];
+fn allergic_to_just_peanuts() {
+    let expected = vec![Allergen::Peanuts];
+    let allergies = Allergies::new(2).allergies();
+
+    compare_allergy_vectors(&expected, &allergies);
+}
+
+#[test]
+#[ignore]
+fn allergic_to_just_strawberries() {
+    let expected = vec![Allergen::Strawberries];
+    let allergies = Allergies::new(8).allergies();
+
+    compare_allergy_vectors(&expected, &allergies);
+}
+
+#[test]
+#[ignore]
+fn allergic_to_eggs_and_peanuts() {
+    let expected = vec![Allergen::Eggs, Allergen::Peanuts];
+    let allergies = Allergies::new(3).allergies();
+
+    compare_allergy_vectors(&expected, &allergies);
+}
+
+#[test]
+#[ignore]
+fn allergic_to_eggs_and_shellfish() {
+    let expected = vec![Allergen::Eggs, Allergen::Shellfish];
+    let allergies = Allergies::new(5).allergies();
+
+    compare_allergy_vectors(&expected, &allergies);
+}
+
+#[test]
+#[ignore]
+fn allergic_to_many_things() {
+    let expected = vec![Allergen::Strawberries,
+                        Allergen::Tomatoes,
+                        Allergen::Chocolate,
+                        Allergen::Pollen,
+                        Allergen::Cats];
+    let allergies = Allergies::new(248).allergies();
+
+    compare_allergy_vectors(&expected, &allergies);
+}
+
+#[test]
+#[ignore]
+fn allergic_to_everything() {
+    let expected = vec![Allergen::Eggs,
+                        Allergen::Peanuts,
+                        Allergen::Shellfish,
+                        Allergen::Strawberries,
+                        Allergen::Tomatoes,
+                        Allergen::Chocolate,
+                        Allergen::Pollen,
+                        Allergen::Cats];
     let allergies = Allergies::new(255).allergies();
 
-    assert_eq!(allergies.len(), all.len());
-
-    for allergy in &all {
-        assert!(allergies.contains(&allergy));
-    }
+    compare_allergy_vectors(&expected, &allergies);
 }
 
 #[test]
 #[ignore]
-fn test_ignore_non_allergen_score_parts() {
-    assert_eq!(vec![Allergen::Eggs], Allergies::new(257).allergies());
+fn scores_over_255_do_not_trigger_false_positives() {
+    let expected = vec![Allergen::Eggs,
+                        Allergen::Shellfish,
+                        Allergen::Strawberries,
+                        Allergen::Tomatoes,
+                        Allergen::Chocolate,
+                        Allergen::Pollen,
+                        Allergen::Cats];
+    let allergies = Allergies::new(509).allergies();
+
+    compare_allergy_vectors(&expected, &allergies);
 }

--- a/exercises/allergies/tests/allergies.rs
+++ b/exercises/allergies/tests/allergies.rs
@@ -3,10 +3,8 @@ extern crate allergies;
 use allergies::*;
 
 fn compare_allergy_vectors(expected: &Vec<Allergen>, actual: &Vec<Allergen>) {
-    assert_eq!(actual.len(), expected.len());
-
-    for allergy in expected {
-        assert!(actual.contains(&allergy));
+    if !expected.iter().eq(actual.iter()) {
+        panic!("Expected {:?}, got {:?}", expected, actual);
     }
 }
 


### PR DESCRIPTION
Fixes #135

- Introducing tests that were missing
- Handling the ordering problem in all tests that check vectors,
  encapsulating the solution introduced in #134
- Updating test names to not start with `test_`
        - Cargo starts each test result line with "test ", followed by
          the test's name.. So these tests looked like "test
          test_allergic_to_peanuts".
- Trying to give the final test a useful name. "ignore non allergen
  score parts" didn't make much sense to me when I worked on this
  exercise. I think the new name better describes what we're trying to
  capture.