### PR TITLE
Collection of small test fixes

### DIFF
--- a/exercises/allergies/tests/allergies.rs
+++ b/exercises/allergies/tests/allergies.rs
@@ -3,8 +3,18 @@ extern crate allergies;
 use allergies::*;
 
 fn compare_allergy_vectors(expected: &Vec<Allergen>, actual: &Vec<Allergen>) {
-    if !expected.iter().eq(actual.iter()) {
-        panic!("Expected {:?}, got {:?}", expected, actual);
+    for element in expected {
+        if !actual.contains(element) {
+            panic!("Allergen missing\n  {:?} should be in {:?}",
+                   element,
+                   actual);
+        }
+    }
+
+    if actual.len() != expected.len() {
+        panic!("Allergy vectors are of different lengths\n  expected {:?}\n  got {:?}",
+               expected,
+               actual);
     }
 }
 

--- a/exercises/pangram/tests/pangram.rs
+++ b/exercises/pangram/tests/pangram.rs
@@ -45,7 +45,7 @@ fn numbers_do_not_affect_pangrams() {
 
 #[test]
 #[ignore]
-fn numbers_can_not_replace_numbers() {
+fn numbers_can_not_replace_letters() {
     let sentence = "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog";
     assert!(!is_pangram(&sentence));
 }

--- a/exercises/wordy/tests/wordy.rs
+++ b/exercises/wordy/tests/wordy.rs
@@ -9,90 +9,105 @@ fn addition() {
 }
 
 #[test]
+#[ignore]
 fn more_addition() {
     let command = "What is 53 plus 2?";
     assert_eq!(55, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn addition_with_negative_numbers() {
     let command = "What is -1 plus -10?";
     assert_eq!(-11, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn large_addition() {
     let command = "What is 123 plus 45678?";
     assert_eq!(45801, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn subtraction() {
     let command = "What is 4 minus -12?";
     assert_eq!(16, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn multiplication() {
     let command = "What is -3 multiplied by 25?";
     assert_eq!(-75, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn division() {
     let command = "What is 33 divided by -3?";
     assert_eq!(-11, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn multiple_additions() {
     let command = "What is 1 plus 1 plus 1?";
     assert_eq!(3, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn addition_and_subtraction() {
     let command = "What is 1 plus 5 minus -2?";
     assert_eq!(8, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn multiple_subtraction() {
     let command = "What is 20 minus 4 minus 13?";
     assert_eq!(3, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn subtraction_then_addition() {
     let command = "What is 17 minus 6 plus 3?";
     assert_eq!(14, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn multiple_multiplications() {
     let command = "What is 2 multiplied by -2 multiplied by 3?";
     assert_eq!(-12, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn addition_and_multiplication() {
     let command = "What is -3 plus 7 multiplied by -2?";
     assert_eq!(-8, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn multiple_divisions() {
     let command = "What is -12 divided by 2 divided by -3?";
     assert_eq!(2, WordProblem::new(command).answer().unwrap());
 }
 
 #[test]
+#[ignore]
 fn unknown_operation() {
     let command = "What is 52 cubed?";
     assert!(WordProblem::new(command).answer().is_err());
 }
 
 #[test]
+#[ignore]
 fn non_math_question() {
     let command = "Who is the President of the United States?";
     assert!(WordProblem::new(command).answer().is_err());


### PR DESCRIPTION
### Fix test name

https://github.com/exercism/xrust/pull/132/files/adc92c53b5b30d446065ec1b69fa245f9c6033a9#r67608318

### Ignore all-but-first test

https://github.com/exercism/xrust/pull/131/files/4599bf939c3e99f89ae4adc64eb647291f6ef0c0#r67608265

### Restore order-independent vector comparison

https://github.com/exercism/xrust/pull/142#issuecomment-226972184

I've returned to the previous way of checking, but with `panic!`s so
that I can return useful error messages.