### PR TITLE
Test that bob responds properly to non-ascii prompts.

### DIFF
--- a/exercises/bob/tests/bob.rs
+++ b/exercises/bob/tests/bob.rs
@@ -53,3 +53,8 @@ fn test_silent_treatment() {
     assert_eq!("Fine. Be that way!", bob::reply(""));
 }
 
+#[test]
+#[ignore]
+fn test_shouting_in_russian() {
+    assert_eq!("Whoa, chill out!", bob::reply("УХОДИ"));
+}


### PR DESCRIPTION
This is just pulled directly from the Elixir bob exercise. Since strings in Rust are UTF8 by default why not have a test phrase with more than ASCII in mind.