### PR TITLE
tournament: rm output files

### DIFF
--- a/exercises/tournament/tests/output1.txt
+++ b/exercises/tournament/tests/output1.txt
@@ -1,5 +1,0 @@
-Team                           | MP |  W |  D |  L |  P
-Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
-Allegoric Alaskians            |  3 |  2 |  0 |  1 |  6
-Blithering Badgers             |  3 |  1 |  0 |  2 |  3
-Courageous Californians        |  3 |  0 |  1 |  2 |  1

--- a/exercises/tournament/tests/output2.txt
+++ b/exercises/tournament/tests/output2.txt
@@ -1,5 +1,0 @@
-Team                           | MP |  W |  D |  L |  P
-Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
-Allegoric Alaskians            |  3 |  2 |  0 |  1 |  6
-Blithering Badgers             |  3 |  1 |  0 |  2 |  3
-Courageous Californians        |  3 |  0 |  1 |  2 |  1

--- a/exercises/tournament/tests/output3.txt
+++ b/exercises/tournament/tests/output3.txt
@@ -1,5 +1,0 @@
-Team                           | MP |  W |  D |  L |  P
-Allegoric Alaskians            |  3 |  2 |  0 |  1 |  6
-Blithering Badgers             |  2 |  1 |  0 |  1 |  3
-Devastating Donkeys            |  1 |  1 |  0 |  0 |  3
-Courageous Californians        |  2 |  0 |  0 |  2 |  0


### PR DESCRIPTION
With these output files present, implementation that do not actually
write files will be able to pass the tests, defeating the purpose. See
PR #153 for an example of such a lazy implementation.

They were added in 65b691e235ff2c0bc908950267917460d765ac48 in what I
can only assume was an accident, since they were added long after the
tournament exercise was added to this track in
ee0a6fde1cc8c6c7d5f984511cc6aaddc6dc75ad.
