### PR TITLE
parallel-letter-frequency, tournament, word-count: Use `Entry#or_insert`

### DIFF
--- a/exercises/grade-school/example.rs
+++ b/exercises/grade-school/example.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::collections::hash_map::Entry;
 
 pub struct School {
     grades: HashMap<u32, Vec<String>>
@@ -11,14 +10,9 @@ impl School {
     }
 
     pub fn add(&mut self, grade: u32, student: &str) {
-        match self.grades.entry(grade) {
-            Entry::Vacant(view) => { view.insert(vec![student.to_string()]); }
-            Entry::Occupied(mut view) => {
-                let l = view.get_mut();
-                l.push(student.to_string());
-                l.sort();
-            },
-        };
+        let mut entry = self.grades.entry(grade).or_insert(Vec::new());
+        entry.push(student.to_string());
+        entry.sort();
     }
     
     pub fn grades(&self) -> Vec<u32> {

--- a/exercises/parallel-letter-frequency/example.rs
+++ b/exercises/parallel-letter-frequency/example.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::collections::hash_map::Entry;
 use std::thread;
 use std::sync::mpsc::channel;
 
@@ -36,12 +35,7 @@ pub fn frequency(texts: &[&str], num_workers: usize) -> HashMap<char, usize> {
     for _ in 0..num_workers {
         let part_results = rx.recv().unwrap();
         for (c, n) in part_results.into_iter() {
-            match results.entry(c) {
-                Entry::Vacant(view) => { view.insert(n); },
-                Entry::Occupied(mut view) => {
-                    *view.get_mut() += n;
-                }
-            }
+            *results.entry(c).or_insert(0) += n;
         }
     }
     results
@@ -52,12 +46,7 @@ fn count(lines: Vec<String>) -> HashMap<char, usize> {
     for line in lines.iter() {
         for c in line.chars() {
             if c.is_alphabetic() {
-                match results.entry(c.to_lowercase().next().unwrap()) {
-                    Entry::Vacant(view) => { view.insert(1); },
-                    Entry::Occupied(mut view) => {
-                        *view.get_mut() += 1;
-                    }
-                }
+                *results.entry(c.to_lowercase().next().unwrap()).or_insert(0) += 1;
             }
         }
     }

--- a/exercises/tournament/example.rs
+++ b/exercises/tournament/example.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering::Equal;
 use std::collections::HashMap;
-use std::collections::hash_map::Entry;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write, Result};
 use std::path::Path;
@@ -87,14 +86,5 @@ fn write_tally(results: &HashMap<String, TeamResult>, output_filename: &Path) ->
 }
 
 fn add_game_result(results: &mut HashMap<String, TeamResult>, team: String, result: GameResult) {
-    match results.entry(team) {
-        Entry::Vacant(entry) => {
-            let mut tr = TeamResult::new();
-            tr.add_game_result(result);
-            entry.insert(tr);
-        }
-        Entry::Occupied(mut entry) => {
-            (*entry.get_mut()).add_game_result(result);
-        }
-    };
+    results.entry(team).or_insert(TeamResult::new()).add_game_result(result);
 }

--- a/exercises/word-count/example.rs
+++ b/exercises/word-count/example.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::collections::hash_map::Entry;
 
 fn lowercase(word: &str) -> String {
     let mut lower = String::with_capacity(word.len());
@@ -16,12 +15,7 @@ pub fn word_count(input: &str) -> HashMap<String, u32> {
     let lower = lowercase(input);
     let slice: &str = lower.as_ref();
     for word in slice.split(|c: char| !c.is_alphanumeric()).filter(|s| !s.is_empty()) {
-        match map.entry(word.to_string()) {
-            Entry::Vacant(entry) => { entry.insert(1); },
-            Entry::Occupied(mut entry) => {
-                *entry.get_mut() += 1;
-            }
-        };
+        *map.entry(word.to_string()).or_insert(0) += 1;
     }
     map
 }


### PR DESCRIPTION
These shorten the functions by removing the need to match on the `Entry` cases.

This seems good to make the examples more idiomatic.

Note the exercises that still match on `Entry` cases but were not changed by this PR:

* ~~grade-school: I judged that pushing an element onto the vector then sorting it was sufficiently different from creating a vector with a single element. I can be convinced otherwise.~~
* nucleotide-count: As we discuss in #149, invalid nucleotides should maybe produce errors, so the decision resulting from that discussion may mean using `or_insert` doesn't make sense.
