### PR TITLE
allergies: replace a match -> bool with a comparison

### DIFF
--- a/exercises/allergies/example.rs
+++ b/exercises/allergies/example.rs
@@ -11,7 +11,7 @@ impl Allergies {
     pub fn is_allergic_to(&self, allergen: &Allergen) -> bool {
         let allergens = Allergies::allergens();
         let index = allergens.iter().position(|x: &Allergen| x == allergen).unwrap();
-        match self.0 & 1 << index { 0 => false, _ => true }
+        (self.0 & (1 << index)) != 0
     }
 
     pub fn allergies(&self) -> Vec<Allergen> {


### PR DESCRIPTION
It feels a bit odd to match when the result is going to be a boolean,
and doesn't feel like an idiomatic use of matching.