### PR TITLE
anagram, word-count: use `str#to_lowercase`

### DIFF
--- a/exercises/anagram/example.rs
+++ b/exercises/anagram/example.rs
@@ -8,22 +8,12 @@ fn sort(word: &String) -> String {
     output
 }
 
-fn lowercase(word: &str) -> String {
-    let mut lower = String::with_capacity(word.len());
-    for c in word.chars() {
-        for low in c.to_lowercase() {
-            lower.push(low);
-        }
-    }
-    lower
-}
-
 pub fn anagrams_for<'a>(word: &str, inputs: &[&'a str]) -> Vec<&'a str> {
-    let lower = lowercase(word);
+    let lower = word.to_lowercase();
     let sorted = sort(&lower);
     let mut anagrams = Vec::new();
     for input in inputs.iter() {
-        let input_lower = lowercase(input);
+        let input_lower = input.to_lowercase();
         if lower != input_lower {
             if sorted == sort(&input_lower) {
                 anagrams.push(*input);

--- a/exercises/word-count/example.rs
+++ b/exercises/word-count/example.rs
@@ -1,19 +1,9 @@
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
-fn lowercase(word: &str) -> String {
-    let mut lower = String::with_capacity(word.len());
-    for c in word.chars() {
-        for low in c.to_lowercase() {
-            lower.push(low);
-        }
-    }
-    lower
-}
-
 pub fn word_count(input: &str) -> HashMap<String, u32> {
     let mut map: HashMap<String, u32> = HashMap::new();
-    let lower = lowercase(input);
+    let lower = input.to_lowercase();
     let slice: &str = lower.as_ref();
     for word in slice.split(|c: char| !c.is_alphanumeric()).filter(|s| !s.is_empty()) {
         match map.entry(word.to_string()) {


### PR DESCRIPTION
This was added in Rust 1.2.0, making the custom `lowercase` function
unnecessary.