### PR TITLE
grade-school: Use `cloned` instead of `map(|k| k.clone())`

### DIFF
--- a/exercises/grade-school/example.rs
+++ b/exercises/grade-school/example.rs
@@ -16,7 +16,7 @@ impl School {
     }
     
     pub fn grades(&self) -> Vec<u32> {
-        let mut s = self.grades.keys().map(|k| k.clone()).collect::<Vec<u32>>();
+        let mut s = self.grades.keys().cloned().collect::<Vec<u32>>();
         s.sort();
         s
     }


### PR DESCRIPTION
They're equivalent, but I figure if there's already a function that does
the clone, might as well use it instead of `map` and making someone read
the body of the map.