### PR TITLE
hello-world: No ref in pattern

### DIFF
--- a/exercises/hello-world/example.rs
+++ b/exercises/hello-world/example.rs
@@ -1,6 +1,6 @@
 pub fn hello(name: Option<&str>) -> String {
     match name {
-        Some(ref n) => format!("Hello, {}!", n),
+        Some(n) => format!("Hello, {}!", n),
         None => "Hello, World!".to_string(),
     }
 }


### PR DESCRIPTION
I couldn't figure out why it was necessary, and I actually didn't know
about it off the top of my head (says something about how much Rust I
know). So I tried to remove it to see what compiler error would happen
if it wasn't there. Nothing, it worked.

Well, if it's not necessary, perhaps we should remove it then... simpler
solution for our first exercise should be good, right?