### PR TITLE
wordy: Immediately return in `operand`

### DIFF
--- a/exercises/wordy/example.rs
+++ b/exercises/wordy/example.rs
@@ -64,8 +64,7 @@ impl WordProblem {
     }
 
     fn operand(&self, t: &Token) -> isize {
-        let x: isize = t.value.parse().unwrap();
-        x
+        t.value.parse().unwrap()
     }
 
     fn operator(&self, t: &Token) -> String {


### PR DESCRIPTION
The previous code just added a `: isize` type, but this is already
inferrable from the function signature, so it can just be returned
immediately.