### PR TITLE
etl: use flat_map

### DIFF
--- a/exercises/etl/example.rs
+++ b/exercises/etl/example.rs
@@ -2,13 +2,7 @@ use std::ascii::AsciiExt;
 use std::collections::BTreeMap;
 
 pub fn transform(input: &BTreeMap<i32, Vec<String>>) -> BTreeMap<String, i32> {
-    let mut output = BTreeMap::new();
-
-    for (&n, vec) in input.iter() {
-        for s in vec.iter() {
-            output.insert(s.to_ascii_lowercase(), n);
-        }
-    }
-
-    output
+    input.iter().flat_map(|(&n, vec)| {
+        vec.iter().map(move |s| (s.to_ascii_lowercase(), n))
+    }).collect()
 }


### PR DESCRIPTION
Instead of creating a `BTreeMap` and adding to it, we can just use
`flat_map` on the input and `collect` the result.