### PR TITLE
Hamming: Make error checking identical to other tests

### DIFF
--- a/exercises/hamming/tests/hamming.rs
+++ b/exercises/hamming/tests/hamming.rs
@@ -32,11 +32,11 @@ fn test_larger_distance() {
 #[test]
 #[ignore]
 fn test_first_string_is_longer() {
-    assert_eq!(dna::hamming_distance("AAA", "AA"), Result::Err("inputs of different length"));
+    assert!(dna::hamming_distance("AAA", "AA").is_err());
 }
 
 #[test]
 #[ignore]
 fn test_second_string_is_longer() {
-    assert_eq!(dna::hamming_distance("A", "AA"), Result::Err("inputs of different length"));
+    assert!(dna::hamming_distance("A", "AA").is_err());
 }


### PR DESCRIPTION
I noticed this after @petertseng mentioned the error handling in [#147](https://github.com/exercism/xrust/pull/147#issuecomment-232076551).
The Hamming exercise performs error checking with comparison to `Err(.)`. Most tests (Nucleotide Codons, Queen Attack, Wordy) only check with `is_err()`. The exceptions are Circular Buffer and Forth, but they use more complex error reporting with different conditions and provide an `Error` enum with the correct return values.

Because there is only one error conditions I suggest to remove the fixed value and only check with `is_err()`.