### PR TITLE
Implement ocr-numbers

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,6 +34,7 @@
     "anagram",
     "nucleotide-codons",
     "robot-name",
+    "ocr-numbers",
     "minesweeper",
     "dominoes",
     "parallel-letter-frequency",

--- a/exercises/ocr-numbers/Cargo.lock
+++ b/exercises/ocr-numbers/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "ocr-numbers"
+version = "0.0.0"
+

--- a/exercises/ocr-numbers/Cargo.toml
+++ b/exercises/ocr-numbers/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "ocr-numbers"
+version = "0.0.0"

--- a/exercises/ocr-numbers/example.rs
+++ b/exercises/ocr-numbers/example.rs
@@ -1,0 +1,67 @@
+use std::collections::BTreeMap;
+use std::str::Lines;
+
+fn lines_valid(lines: &Lines) -> bool {
+    lines.clone().count() % 4 == 0 && lines.clone().all(|line| line.chars().count() % 3 == 0)
+}
+
+pub fn convert(input: &str) -> Result<String, ()> {
+    if !lines_valid(&input.lines()) {
+        return Err(());
+    }
+
+    let y = input.lines().collect::<Vec<_>>();
+
+    let mut converted_lines = vec![];
+
+    for char_lines in y.chunks(4) {
+        let mut unparsed_characters = BTreeMap::new();
+
+        for line in char_lines {
+            let line_chars = line.chars().collect::<Vec<_>>();
+
+            for (char_number, char_chunk) in line_chars.chunks(3).enumerate() {
+                let char_chars = unparsed_characters.entry(char_number).or_insert(vec![]);
+                for c in char_chunk {
+                    char_chars.push(*c);
+                }
+            }
+        }
+
+        let mut parsed_characters = String::new();
+
+        for (_, v) in unparsed_characters {
+            parsed_characters.push(convert_character(&v));
+        }
+
+        converted_lines.push(parsed_characters.to_string());
+    }
+
+    Ok(converted_lines.join(","))
+}
+
+fn convert_character(input: &Vec<char>) -> char {
+    if &input[..] == [' ', '_', ' ', '|', ' ', '|', '|', '_', '|', ' ', ' ', ' '] {
+        '0'
+    } else if &input[..] == [' ', ' ', ' ', ' ', ' ', '|', ' ', ' ', '|', ' ', ' ', ' '] {
+        '1'
+    } else if &input[..] == [' ', '_', ' ', ' ', '_', '|', '|', '_', ' ', ' ', ' ', ' '] {
+        '2'
+    } else if &input[..] == [' ', '_', ' ', ' ', '_', '|', ' ', '_', '|', ' ', ' ', ' '] {
+        '3'
+    } else if &input[..] == [' ', ' ', ' ', '|', '_', '|', ' ', ' ', '|', ' ', ' ', ' '] {
+        '4'
+    } else if &input[..] == [' ', '_', ' ', '|', '_', ' ', ' ', '_', '|', ' ', ' ', ' '] {
+        '5'
+    } else if &input[..] == [' ', '_', ' ', '|', '_', ' ', '|', '_', '|', ' ', ' ', ' '] {
+        '6'
+    } else if &input[..] == [' ', '_', ' ', ' ', ' ', '|', ' ', ' ', '|', ' ', ' ', ' '] {
+        '7'
+    } else if &input[..] == [' ', '_', ' ', '|', '_', '|', '|', '_', '|', ' ', ' ', ' '] {
+        '8'
+    } else if &input[..] == [' ', '_', ' ', '|', '_', '|', ' ', '_', '|', ' ', ' ', ' '] {
+        '9'
+    } else {
+        '?'
+    }
+}

--- a/exercises/ocr-numbers/src/lib.rs
+++ b/exercises/ocr-numbers/src/lib.rs
@@ -1,0 +1,7 @@
+// The code below is a stub. Just enough to satisfy the compiler.
+// In order to pass the tests you can add-to or change any of this code.
+
+#[allow(unused_variables)]
+pub fn convert(input: &str) -> Result<String, ()> {
+    unimplemented!();
+}

--- a/exercises/ocr-numbers/tests/ocr-numbers.rs
+++ b/exercises/ocr-numbers/tests/ocr-numbers.rs
@@ -1,0 +1,211 @@
+extern crate ocr_numbers as ocr;
+
+#[test]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn input_with_lines_not_multiple_of_four_is_error() {
+    let input = " _ \n".to_string() +
+                "| |\n" +
+                "   ";
+
+    assert!(ocr::convert(&input).is_err());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn input_with_columns_not_multiple_of_three_is_error() {
+    let input = "    \n".to_string() +
+                "   |\n" +
+                "   |\n" +
+                "    ";
+
+    assert!(ocr::convert(&input).is_err());
+}
+
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn unrecognized_chararcters_return_question_mark() {
+    let input = "   \n".to_string() +
+                "  _\n" +
+                "  |\n" +
+                "   ";
+
+    assert_eq!("?", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn recognizes_0() {
+    let input = " _ \n".to_string() +
+                "| |\n" +
+                "|_|\n" +
+                "   ";
+
+    assert_eq!("0", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn recognizes_1() {
+    let input = "   \n".to_string() +
+                "  |\n" +
+                "  |\n" +
+                "   ";
+
+    assert_eq!("1", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn recognizes_2() {
+    let input = " _ \n".to_string() +
+                " _|\n" +
+                "|_ \n" +
+                "   ";
+
+    assert_eq!("2", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn recognizes_3() {
+    let input = " _ \n".to_string() +
+                " _|\n" +
+                " _|\n" +
+                "   ";
+
+    assert_eq!("3", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn recognizes_4() {
+    let input = "   \n".to_string() +
+                "|_|\n" +
+                "  |\n" +
+                "   ";
+
+    assert_eq!("4", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn recognizes_5() {
+    let input = " _ \n".to_string() +
+                "|_ \n" +
+                " _|\n" +
+                "   ";
+
+    assert_eq!("5", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn recognizes_6() {
+    let input = " _ \n".to_string() +
+                "|_ \n" +
+                "|_|\n" +
+                "   ";
+
+    assert_eq!("6", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn recognizes_7() {
+    let input = " _ \n".to_string() +
+                "  |\n" +
+                "  |\n" +
+                "   ";
+
+    assert_eq!("7", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn recognizes_8() {
+    let input = " _ \n".to_string() +
+                "|_|\n" +
+                "|_|\n" +
+                "   ";
+
+    assert_eq!("8", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn recognizes_9() {
+    let input = " _ \n".to_string() +
+                "|_|\n" +
+                " _|\n" +
+                "   ";
+
+    assert_eq!("9", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn recognizes_110101100() {
+    let input = "       _     _        _  _ \n".to_string() +
+                "  |  || |  || |  |  || || |\n" +
+                "  |  ||_|  ||_|  |  ||_||_|\n" +
+                "                           ";
+
+    assert_eq!("110101100", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn replaces_only_garbled_numbers_with_question_mark() {
+    let input = "       _     _           _ \n".to_string() +
+                "  |  || |  || |     || || |\n" +
+                "  |  | _|  ||_|  |  ||_||_|\n" +
+                "                           ";
+
+    assert_eq!("11?10?1?0", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn recognizes_string_of_decimal_numbers() {
+    let input = "    _  _     _  _  _  _  _  _ \n".to_string() +
+                "  | _| _||_||_ |_   ||_||_|| |\n" +
+                "  ||_  _|  | _||_|  ||_| _||_|\n" +
+                "                              ";
+
+    assert_eq!("1234567890", ocr::convert(&input).unwrap());
+}
+
+#[test]
+#[ignore]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn numbers_across_multiple_lines_are_joined_by_commas() {
+    let input = "    _  _ \n".to_string() +
+                "  | _| _|\n" +
+                "  ||_  _|\n" +
+                "         \n" +
+                "    _  _ \n" +
+                "|_||_ |_ \n" +
+                "  | _||_|\n" +
+                "         \n" +
+                " _  _  _ \n" +
+                "  ||_||_|\n" +
+                "  ||_| _|\n" +
+                "         ";
+    assert_eq!("123,456,789", ocr::convert(&input).unwrap());
+}

--- a/problems.md
+++ b/problems.md
@@ -67,6 +67,7 @@ These problems don’t necessarily require additional Rust knowledge, but they d
 
 problem | topics
 ----- | -----
+ocr-numbers | Lines, Chunks, slices
 minesweeper |  Board state
 dominoes |  Graph theory, searching
 parallel-letter-frequency | multi-threading


### PR DESCRIPTION
This is not ready for merge. Just getting it up here so that we can start the discussion/bikeshedding.

I've created the tests and the stub file. No working implementation yet. I'm really not sure what implementations people will use for this one. Will be interesting to see.

The one goofy thing I've done here is turn off rustfmt for each test. I don't see a way to turn it off at the file or directory level. I've confirmed that currently a [directory-level ignore (https://github.com/rust-lang-nursery/rustfmt/issues/705) is not supported. But maybe there's a file wide directive that I'm missing?