### PR TITLE
Use [] instead of () for vec!

### DIFF
--- a/exercises/grade-school/tests/grade-school.rs
+++ b/exercises/grade-school/tests/grade-school.rs
@@ -15,7 +15,7 @@ fn test_grades_for_empty_school() {
 fn test_grades_for_one_student() {
     let mut s = school::School::new();
     s.add(2, "Aimee");
-    assert_eq!(s.grades(), vec!(2));
+    assert_eq!(s.grades(), vec![2]);
 }
 
 #[test]
@@ -25,7 +25,7 @@ fn test_grades_for_several_students_are_sorted() {
     s.add(2, "Aimee");
     s.add(7, "Logan");
     s.add(4, "Blair");
-    assert_eq!(s.grades(), vec!(2, 4, 7));
+    assert_eq!(s.grades(), vec![2, 4, 7]);
 }
 
 #[test]
@@ -35,7 +35,7 @@ fn test_grades_when_several_students_have_the_same_grade() {
     s.add(2, "Aimee");
     s.add(2, "Logan");
     s.add(2, "Blair");
-    assert_eq!(s.grades(), vec!(2));
+    assert_eq!(s.grades(), vec![2]);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_grade_for_one_student() {
     let mut s = school::School::new();
     s.add(2, "Aimee");
     assert_eq!(s.grade(2).map(|v| stringvec_to_strvec(v)),
-                Some(vec!("Aimee")))
+                Some(vec!["Aimee"]))
 }
 
 #[test]
@@ -70,7 +70,7 @@ fn test_grade_returns_students_sorted_by_name() {
     s.add(2, "Blair");
     s.add(2, "Paul");
     assert_eq!(s.grade(2).map(|v| stringvec_to_strvec(v)),
-               Some(vec!("Blair", "James", "Paul")));
+               Some(vec!["Blair", "James", "Paul"]));
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn test_add_students_to_different_grades() {
     s.add(7, "Logan");
     assert_eq!(s.grades(), vec!(3, 7));
     assert_eq!(s.grade(3).map(|v| stringvec_to_strvec(v)),
-               Some(vec!("Chelsea")));
+               Some(vec!["Chelsea"]));
     assert_eq!(s.grade(7).map(|v| stringvec_to_strvec(v)),
-               Some(vec!("Logan")));
+               Some(vec!["Logan"]));
 }


### PR DESCRIPTION
This is the idiomatic and recommended style for this macro.

> (Notice that unlike the println! macro we’ve used in the past, we use
> square brackets [] with vec! macro. Rust allows you to use either in
> either situation, this is just convention.)
>
> https://doc.rust-lang.org/book/vectors.html