### PR TITLE
Test anagram for same bytes but different chars

### DIFF
--- a/exercises/anagram/tests/anagram.rs
+++ b/exercises/anagram/tests/anagram.rs
@@ -100,3 +100,13 @@ fn test_does_not_detect_a_differently_cased_unicode_word_as_its_own_anagram() {
     let outputs: Vec<&str> = vec![];
     assert_eq!(anagram::anagrams_for("ΑΒΓ", &inputs), outputs);
 }
+
+#[test]
+#[ignore]
+fn test_same_bytes_different_chars() {
+    let inputs = ["€a"]; // E2 82 AC 61
+    let outputs: Vec<&str> = vec![];
+    assert_eq!(anagram::anagrams_for(
+        "a⬂", // 61 E2 AC 82
+        &inputs), outputs);
+}


### PR DESCRIPTION
One can currently pass the tests by comparing a sorted `into_bytes()`, but the same bytes may represent different `char`s.