### PR TITLE
Test variable-length-quantity for an incomplete byte sequence of zero

### DIFF
--- a/exercises/variable-length-quantity/example.rs
+++ b/exercises/variable-length-quantity/example.rs
@@ -71,7 +71,7 @@ fn to_bytes_single(mut value: u32) -> Vec<u8> {
 pub fn from_bytes(bytes: &[u8]) -> Result<Vec<u32>, &'static str> {
     let mut res = vec![];
     let mut tmp = 0;
-    for b in bytes {
+    for (i,b) in bytes.iter().enumerate() {
         // test if first 7 bit are set, to check for overflow
         if (tmp & 0xfe_00_00_00) > 0 {
             return Err("Would overflow");
@@ -84,13 +84,16 @@ pub fn from_bytes(bytes: &[u8]) -> Result<Vec<u32>, &'static str> {
             // continuation bit not set, number if complete
             res.push(tmp);
             tmp = 0;
+        } else {
+            // check for incomplete bytes
+            if i+1 == bytes.len() {
+                // the next index would be past the end,
+                // i.e. there are no more bytes.
+                return Err("Incomplete byte sequence");
+            }
         }
     }
 
-    // check for incomplete bytes
-    if tmp != 0 {
-        return Err("Incomplete byte sequence");
-    }
 
     Ok(res)
 }

--- a/exercises/variable-length-quantity/tests/variable-length-quantity.rs
+++ b/exercises/variable-length-quantity/tests/variable-length-quantity.rs
@@ -89,6 +89,12 @@ fn incomplete_byte_sequence() {
 
 #[test]
 #[ignore]
+fn zero_incomplete_byte_sequence() {
+    assert!(vlq::from_bytes(&[0x80]).is_err());
+}
+
+#[test]
+#[ignore]
 fn overflow_u32() {
     assert!(vlq::from_bytes(&[0xff, 0xff, 0xff, 0xff, 0x7f]).is_err());
 }


### PR DESCRIPTION
My initial solution to this exercise decided if a byte sequence was incomplete based on whether the accumulator/total is zero when you run out of bytes. This works for the current test case, `0xff`, which leaves `0x7f` in your accumulator, but not for `0x80`.