### PR TITLE
Implement Space Age

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,6 +26,7 @@
     "robot-simulator",
     "queen-attack",
     "sublist",
+    "space-age",
     "allergies",
     "variable-length-quantity",
     "phone-number",

--- a/exercises/space-age/Cargo.lock
+++ b/exercises/space-age/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "space-age"
+version = "0.0.0"
+

--- a/exercises/space-age/Cargo.toml
+++ b/exercises/space-age/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "space-age"
+version = "0.0.0"

--- a/exercises/space-age/example.rs
+++ b/exercises/space-age/example.rs
@@ -1,0 +1,79 @@
+pub struct Duration {
+    seconds: f64,
+}
+
+impl From<u64> for Duration {
+    fn from(s: u64) -> Self {
+        Duration { seconds: s as f64 }
+    }
+}
+
+impl From<f64> for Duration {
+    fn from(s: f64) -> Self {
+        Duration { seconds: s }
+    }
+}
+
+pub trait Planet {
+    fn orbital_duration() -> Duration;
+    fn years_during(d: &Duration) -> f64 {
+        d.seconds / Self::orbital_duration().seconds
+    }
+}
+
+pub struct Mercury;
+pub struct Venus;
+pub struct Earth;
+pub struct Mars;
+pub struct Jupiter;
+pub struct Saturn;
+pub struct Uranus;
+pub struct Neptune;
+
+impl Planet for Mercury {
+    fn orbital_duration() -> Duration {
+        Duration::from(7600543.81992)
+    }
+}
+
+impl Planet for Venus {
+    fn orbital_duration() -> Duration {
+        Duration::from(19414149.052176)
+    }
+}
+
+impl Planet for Earth {
+    fn orbital_duration() -> Duration {
+        Duration::from(31557600)
+    }
+}
+
+impl Planet for Mars {
+    fn orbital_duration() -> Duration {
+        Duration::from(59354032.69008)
+    }
+}
+
+impl Planet for Jupiter {
+    fn orbital_duration() -> Duration {
+        Duration::from(374355659.124)
+    }
+}
+
+impl Planet for Saturn {
+    fn orbital_duration() -> Duration {
+        Duration::from(929292362.8848)
+    }
+}
+
+impl Planet for Uranus {
+    fn orbital_duration() -> Duration {
+        Duration::from(2651370019.3296)
+    }
+}
+
+impl Planet for Neptune {
+    fn orbital_duration() -> Duration {
+        Duration::from(5200418560.032)
+    }
+}

--- a/exercises/space-age/src/lib.rs
+++ b/exercises/space-age/src/lib.rs
@@ -1,0 +1,35 @@
+// The code below is a stub. Just enough to satisfy the compiler.
+// In order to pass the tests you can add-to or change any of this code.
+#![allow(unused_variables)]
+
+pub struct Duration;
+
+impl From<u64> for Duration {
+    fn from(s: u64) -> Self {
+        unimplemented!()
+    }
+}
+
+pub trait Planet {
+    fn years_during(d: &Duration) -> f64 {
+        unimplemented!();
+    }
+}
+
+pub struct Mercury;
+pub struct Venus;
+pub struct Earth;
+pub struct Mars;
+pub struct Jupiter;
+pub struct Saturn;
+pub struct Uranus;
+pub struct Neptune;
+
+impl Planet for Mercury {}
+impl Planet for Venus {}
+impl Planet for Earth {}
+impl Planet for Mars {}
+impl Planet for Jupiter {}
+impl Planet for Saturn {}
+impl Planet for Uranus {}
+impl Planet for Neptune {}

--- a/exercises/space-age/tests/space-age.rs
+++ b/exercises/space-age/tests/space-age.rs
@@ -1,0 +1,69 @@
+extern crate space_age;
+
+use space_age::*;
+
+fn assert_in_delta(expected: f64, actual: f64) {
+    let diff: f64 = expected - actual.abs();
+    let delta: f64 = 0.01;
+    if diff > delta {
+        panic!("Your result of {} should be within {} of the expected result {}",
+               actual,
+               delta,
+               expected)
+    }
+}
+
+#[test]
+fn earth_age() {
+    let duration = Duration::from(1_000_000_000);
+    assert_in_delta(31.69, Earth::years_during(&duration));
+}
+
+#[test]
+#[ignore]
+fn mercury_age() {
+    let duration = Duration::from(2_134_835_688);
+    assert_in_delta(280.88, Mercury::years_during(&duration));
+}
+
+#[test]
+#[ignore]
+fn venus_age() {
+    let duration = Duration::from(189_839_836);
+    assert_in_delta(9.78, Venus::years_during(&duration));
+}
+
+#[test]
+#[ignore]
+fn mars_age() {
+    let duration = Duration::from(2_329_871_239);
+    assert_in_delta(39.25, Mars::years_during(&duration));
+}
+
+#[test]
+#[ignore]
+fn jupiter_age() {
+    let duration = Duration::from(901_876_382);
+    assert_in_delta(2.41, Jupiter::years_during(&duration));
+}
+
+#[test]
+#[ignore]
+fn saturn_age() {
+    let duration = Duration::from(3_000_000_000);
+    assert_in_delta(3.23, Saturn::years_during(&duration));
+}
+
+#[test]
+#[ignore]
+fn uranus_age() {
+    let duration = Duration::from(3_210_123_456);
+    assert_in_delta(1.21, Uranus::years_during(&duration));
+}
+
+#[test]
+#[ignore]
+fn neptune_age() {
+    let duration = Duration::from(8_210_123_456);
+    assert_in_delta(1.58, Neptune::years_during(&duration));
+}

--- a/exercises/space-age/topics.md
+++ b/exercises/space-age/topics.md
@@ -1,0 +1,6 @@
+# Topics
+
+Some Rust topics you may want to read about while solving this problem:
+
+- Traits, both the From trait and implementing your own traits
+- Default method implementations for traits

--- a/problems.md
+++ b/problems.md
@@ -45,6 +45,7 @@ tournament |  enum, sorting, hashmap, structs
 robot-simulator | Immutability, enum
 queen-attack |  struct, trait (optional), Result
 sublist |  enum, generic over type
+space-age | Custom Trait, From Trait, Default Trait implementation
 allergies |  struct, enum, bitwise (probably), vectors, filter
 variable-length-quantity | Encodings, slices, bitwise, Result
 phone-number |  option, format, unwrap_or, iters, match


### PR DESCRIPTION
First version that passes the tests.

This first commit is intended so we can discuss the crate's API and the tests. There are two decisions I made here that I can see people finding odd.

1. Creating each class as a separate struct.
 - I did this because I want students to learn about traits. Obviously they'll have do deal with the `From` trait, but I can also see implementations grappling with shared behavior between the various planets that can be handled via traits.
2. ~~Testing that a struct is equal to a float~~ This was dumb

I'm not bound to either of these decisions, but they were intentional.

### To Do Before Merge

- [x] Confirm API makes sense
- [x] Add test helper that can compare floats
-  ~~Update example code to implement `From<u64>` and `From<f64>` generically~~ Skipping, not necessary and probably requires the `num` crate anyway.
- [x] Can we add to Readme with links to Traits & From?
- [x] Placing it in the problem order
