### PR TITLE
Implement Bracket Push

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,6 +24,7 @@
     "grade-school",
     "tournament",
     "robot-simulator",
+    "bracket-push",
     "queen-attack",
     "sublist",
     "space-age",

--- a/exercises/bracket-push/Cargo.lock
+++ b/exercises/bracket-push/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "bracket-push"
+version = "0.0.0"
+

--- a/exercises/bracket-push/Cargo.toml
+++ b/exercises/bracket-push/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "bracket-push"
+version = "0.0.0"

--- a/exercises/bracket-push/HINTS.md
+++ b/exercises/bracket-push/HINTS.md
@@ -1,0 +1,6 @@
+# Bracket Push in Rust
+
+Reading about these Rust topics may help you implement a solution.
+
+- Lifetimes and Structs: https://doc.rust-lang.org/book/lifetimes.html#impl-blocks
+- From trait: https://doc.rust-lang.org/std/convert/trait.From.html

--- a/exercises/bracket-push/example.rs
+++ b/exercises/bracket-push/example.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+
+pub struct Brackets {
+    raw_brackets: Vec<char>,
+    pairs: MatchingBrackets,
+}
+
+impl<'a> From<&'a str> for Brackets {
+    fn from(i: &str) -> Self {
+        Brackets::new(String::from(i), None)
+    }
+}
+
+impl Brackets {
+    pub fn new(s: String, pairs: Option<Vec<(char, char)>>) -> Self {
+        let p = match pairs {
+            Some(x) => MatchingBrackets::from(x),
+            None => MatchingBrackets::from(vec![('[', ']'), ('{', '}'), ('(', ')')]),
+        };
+
+        Brackets {
+            raw_brackets: s.chars().filter(|c| p.contains(&c)).collect::<Vec<char>>(),
+            pairs: p,
+        }
+    }
+
+    pub fn are_balanced(&self) -> bool {
+        let mut unclosed: Vec<char> = Vec::new();
+
+        for &bracket in self.raw_brackets.iter() {
+            if let Some(last_unclosed) = unclosed.pop() {
+                unclosed.extend(self.pairs.unmatched(last_unclosed, bracket));
+            } else {
+                unclosed.push(bracket);
+            }
+        }
+
+        unclosed.is_empty()
+    }
+}
+
+pub struct MatchingBrackets {
+    collection: HashMap<char, char>,
+}
+
+impl From<Vec<(char, char)>> for MatchingBrackets {
+    fn from(v: Vec<(char, char)>) -> Self {
+        MatchingBrackets { collection: v.into_iter().collect::<HashMap<char, char>>() }
+    }
+}
+
+impl MatchingBrackets {
+    fn contains(&self, other: &char) -> bool {
+        let known = self.collection.keys().chain(self.collection.values()).collect::<Vec<_>>();
+        known.contains(&other)
+    }
+
+    fn closer_for(&self, k: &char) -> Option<&char> {
+        self.collection.get(k)
+    }
+
+    fn closed_by(&self, l: char, r: char) -> bool {
+        match self.closer_for(&l) {
+            Some(&x) => r == x,
+            None => false,
+        }
+    }
+
+    fn unmatched(&self, open: char, potential_close: char) -> Vec<char> {
+        let mut ret: Vec<char> = Vec::new();
+
+        if !self.closed_by(open, potential_close) {
+            ret.push(open);
+            ret.push(potential_close);
+        }
+
+        ret
+    }
+}

--- a/exercises/bracket-push/tests/bracket-push.rs
+++ b/exercises/bracket-push/tests/bracket-push.rs
@@ -1,0 +1,82 @@
+extern crate bracket_push;
+
+use bracket_push::*;
+
+#[test]
+fn paired_square_brackets() {
+    assert!(Brackets::from("[]").are_balanced());
+}
+
+#[test]
+#[ignore]
+fn empty_string() {
+    assert!(Brackets::from("").are_balanced());
+}
+
+#[test]
+#[ignore]
+fn unpaired_brackets() {
+    assert!(!Brackets::from("[[").are_balanced());
+}
+
+#[test]
+#[ignore]
+fn wrong_ordered_brackets() {
+    assert!(!Brackets::from("}{").are_balanced());
+}
+
+#[test]
+#[ignore]
+fn paired_with_whitespace() {
+    assert!(Brackets::from("{ }").are_balanced());
+}
+
+#[test]
+#[ignore]
+fn simple_nested_brackets() {
+    assert!(Brackets::from("{[]}").are_balanced());
+}
+
+#[test]
+#[ignore]
+fn several_paired_brackets() {
+    assert!(Brackets::from("{}[]").are_balanced());
+}
+
+#[test]
+#[ignore]
+fn paired_and_nested_brackets() {
+    assert!(Brackets::from("([{}({}[])])").are_balanced());
+}
+
+#[test]
+#[ignore]
+fn unopened_closing_brackets() {
+    assert!(!Brackets::from("{[)][]}").are_balanced());
+}
+
+#[test]
+#[ignore]
+fn unpaired_and_nested_brackets() {
+    assert!(!Brackets::from("([{])").are_balanced());
+}
+
+#[test]
+#[ignore]
+fn paired_and_wrong_nested_brackets() {
+    assert!(!Brackets::from("[({]})").are_balanced());
+}
+
+#[test]
+#[ignore]
+fn math_expression() {
+    assert!(Brackets::from("(((185 + 223.85) * 15) - 543)/2").are_balanced());
+}
+
+#[test]
+#[ignore]
+fn complex_latex_expression() {
+    let input = "\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ \\mathrm{e}^{x} &... x^2 \
+                 \\end{array}\\right)";
+    assert!(Brackets::from(input).are_balanced());
+}

--- a/problems.md
+++ b/problems.md
@@ -43,6 +43,7 @@ hexadecimal |  Option, zip/fold/chars, map
 grade-school |  struct, entry api, Vec, Option
 tournament |  enum, sorting, hashmap, structs
 robot-simulator | Immutability, enum
+bracket-push | From trait, stack or recursion
 queen-attack |  struct, trait (optional), Result
 sublist |  enum, generic over type
 space-age | Custom Trait, From Trait, Default Trait implementation


### PR DESCRIPTION
I'm on the fence about using `&str`. If we don't provide the stub file, it will increase the difficulty of implementing `from`.

But if we include the stub file, then there's almost no extra work involved. Which also might reduce the amount students learn from the exercise.

Sometimes you gotta work with borrowed stuff, right? Writing a `from` implementation for a borrow seems like a useful thing to learn.

So I think my current wish is to:

- Write the tests to expect `From<&'a str>` (`From<&'static str>` would also work, I think)
- Don't include the stub file
