### PR TITLE
nucleotide-count: Use `Entry#or_insert`

### DIFF
--- a/exercises/nucleotide-count/example.rs
+++ b/exercises/nucleotide-count/example.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::collections::hash_map::Entry;
 
 pub fn count(nucleotide: char, input: &str) -> usize {
     input.chars().filter(|&c| c == nucleotide).count()
@@ -8,13 +7,7 @@ pub fn count(nucleotide: char, input: &str) -> usize {
 pub fn nucleotide_counts(input: &str) -> HashMap<char, usize> {
     let mut map: HashMap<char, usize> = "ACGT".chars().map(|c| (c, 0)).collect();
     for nucleotide in input.chars() {
-        match map.entry(nucleotide) {
-            Entry::Vacant(view) => view.insert(1),
-            Entry::Occupied(mut view) => {
-                *view.get_mut() += 1;
-                view.into_mut()
-            }
-        };
+        *map.entry(nucleotide).or_insert(0) += 1;
     }
     map
 }


### PR DESCRIPTION
In #155, this operation was performed for other exercises (tournament,
parallel-letter-frequency, word-count), but nucleotide-count was skipped
because #149 indicates that invalid nucleotides maybe should produce
errors.

We don't need to wait for x-common to get a nucleotide-count.json before
deciding to make the current implementation more idiomatic though.

If it's eventually decided that `or_insert` doesn't make sense, we can
change it then.