### PR TITLE
Add React

### DIFF
--- a/config.json
+++ b/config.json
@@ -41,7 +41,8 @@
     "parallel-letter-frequency",
     "rectangles",
     "forth",
-    "circular-buffer"
+    "circular-buffer",
+    "react"
   ],
   "deprecated": [
 

--- a/exercises/react/Cargo.lock
+++ b/exercises/react/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "react"
+version = "0.0.0"
+

--- a/exercises/react/Cargo.toml
+++ b/exercises/react/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "react"
+version = "0.0.0"

--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -1,24 +1,40 @@
-// TODO: For now, lib is symlinked to example to ease local development.
-// But the final plan is to provide a stub file once we know what the interface will be.
+use std::collections::HashMap;
 
 pub type CellID = usize;
+pub type CallbackID = usize;
 
-pub struct Cell<'a, T: Copy> {
-    val: T,
+struct Cell<'a, T: Copy> {
+    value: T,
+    last_value: T,
     dependents: Vec<CellID>,
     cell_type: CellType<'a, T>,
+    callbacks_issued: usize,
+    callbacks: HashMap<CallbackID, Box<FnMut(T) -> () + 'a>>,
 }
 
-pub enum CellType<'a, T: Copy> {
+enum CellType<'a, T: Copy> {
     Input,
     Compute(Vec<CellID>, Box<Fn(&[T]) -> T + 'a>),
+}
+
+impl <'a, T: Copy> Cell<'a, T> {
+    fn new(initial: T, cell_type: CellType<'a, T>) -> Self {
+        Cell {
+            value: initial,
+            last_value: initial,
+            dependents: Vec::new(),
+            cell_type: cell_type,
+            callbacks_issued: 0,
+            callbacks: HashMap::new(),
+        }
+    }
 }
 
 pub struct Reactor<'a, T: Copy> {
     cells: Vec<Cell<'a, T>>,
 }
 
-impl <'a, T: Copy> Reactor<'a, T> {
+impl <'a, T: Copy + PartialEq> Reactor<'a, T> {
     pub fn new() -> Self {
         Reactor{
             cells: Vec::new(),
@@ -26,43 +42,122 @@ impl <'a, T: Copy> Reactor<'a, T> {
     }
 
     pub fn create_input(&mut self, initial: T) -> CellID {
-        self.cells.push(Cell {
-            val: initial,
-            dependents: Vec::new(),
-            cell_type: CellType::Input,
-        });
+        self.cells.push(Cell::new(initial, CellType::Input));
         self.cells.len() - 1
     }
 
-    pub fn create_compute<F: Fn(&[T]) -> T + 'a>(&mut self, dependencies: &[CellID], compute_func: F) -> CellID {
-        let inputs: Vec<_> = dependencies.iter().map(|&id| self.get(id).unwrap().value()).collect();
+    pub fn create_compute<F: Fn(&[T]) -> T + 'a>(&mut self, dependencies: &[CellID], compute_func: F) -> Result<CellID, &'static str> {
+        let new_id = self.cells.len();
+        for &id in dependencies {
+            match self.cells.get_mut(id) {
+                Some(c) => c.dependents.push(new_id),
+                None => return Err("Nonexistent input"),
+            }
+        }
+        let inputs: Vec<_> = dependencies.iter().map(|&id| self.value(id).unwrap()).collect();
         let initial = compute_func(&inputs);
-        self.cells.push(Cell {
-            val: initial,
-            dependents: Vec::new(),
-            cell_type: CellType::Compute(dependencies.iter().cloned().collect(), Box::new(compute_func)),
-        });
-        self.cells.len() - 1
+        self.cells.push(Cell::new(initial, CellType::Compute(dependencies.iter().cloned().collect(), Box::new(compute_func))));
+        Ok(new_id)
     }
 
-    pub fn get(&self, id: CellID) -> Option<&Cell<'a, T>> {
-        self.cells.get(id)
+    pub fn value(&self, id: CellID) -> Option<T> {
+        self.cells.get(id).map(|c| c.value)
     }
 
-    pub fn get_mut(&mut self, id: CellID) -> Option<&mut Cell<'a, T>> {
-        self.cells.get_mut(id)
+    pub fn set_value(&mut self, id: CellID, new_value: T) -> Result<(), &'static str> {
+        match self.cells.get_mut(id) {
+            Some(c) => match c.cell_type {
+                CellType::Input => {
+                    c.value = new_value;
+                    Ok(c.dependents.clone())
+                },
+                CellType::Compute(_, _) => Err("Can't set compute cell value directly"),
+            },
+            None => Err("Can't set nonexistent cell"),
+        }.map(|deps| {
+            for &d in deps.iter() {
+                self.update_dependent(d);
+            }
+            // We can only fire callbacks after all dependents have updated.
+            // So we can't combine this for loop with the one above!
+            for d in deps {
+                self.fire_callbacks(d);
+            }
+        })
     }
-}
 
-impl <'a, T: Copy> Cell<'a, T> {
-    pub fn value(&self) -> T {
-        self.val
+    pub fn add_callback<F: FnMut(T) -> () + 'a>(&mut self, id: CellID, callback: F) -> Result<CallbackID, &'static str> {
+        match self.cells.get_mut(id) {
+            Some(c) => {
+                c.callbacks_issued += 1;
+                c.callbacks.insert(c.callbacks_issued, Box::new(callback));
+                Ok(c.callbacks_issued)
+            },
+            None => Err("Can't add callback to nonexistent cell"),
+        }
     }
 
-    pub fn set_value(&mut self, new_val: T) {
-        match self.cell_type {
-            CellType::Input => self.val = new_val,
-            CellType::Compute(_, _) => panic!("Can't set compute value directly"),
+    pub fn remove_callback(&mut self, cell: CellID, callback: CallbackID) -> Result<(), &'static str> {
+        match self.cells.get_mut(cell) {
+            Some(c) => match c.callbacks.remove(&callback) {
+                Some(_) => Ok(()),
+                None => Err("Can't remove nonexistent callback"),
+            },
+            None => Err("Can't remove callback from nonexistent cell"),
+        }
+    }
+
+    fn update_dependent(&mut self, id: CellID) {
+        let (new_value, dependents) = {
+            // This block limits the scope of the self.cells borrow.
+            // This is necessary becaue we borrow it mutably below.
+            let (dependencies, f, dependents) = match self.cells.get(id) {
+                Some(c) => match c.cell_type {
+                    CellType::Input => panic!("Input cell can't be a dependent"),
+                    CellType::Compute(ref dependencies, ref f) => (dependencies, f, c.dependents.clone()),
+                },
+                None => panic!("Cell to update disappeared while querying"),
+            };
+            let inputs: Vec<_> = dependencies.iter().map(|&id| self.value(id).unwrap()).collect();
+            (f(&inputs), dependents)
+        };
+
+        match self.cells.get_mut(id) {
+            Some(c) => {
+                if c.value == new_value {
+                    // No change here, we don't need to update our dependents.
+                    // (It wouldn't hurt to, but it would be unnecessary work)
+                    return;
+                }
+                c.value = new_value;
+            },
+            None => panic!("Cell to update disappeared while updating"),
+        }
+
+        for d in dependents {
+            self.update_dependent(d);
+        }
+    }
+
+    fn fire_callbacks(&mut self, id: CellID) {
+        let dependents = match self.cells.get_mut(id) {
+            Some(c) => {
+                if c.value == c.last_value {
+                    // Value hasn't changed since last callback fire.
+                    // We thus shouldn't fire the callbacks.
+                    return
+                }
+                for cb in c.callbacks.values_mut() {
+                    cb(c.value);
+                }
+                c.last_value = c.value;
+                c.dependents.clone()
+            },
+            None => panic!("Callback cell disappeared"),
+        };
+
+        for d in dependents {
+            self.fire_callbacks(d);
         }
     }
 }

--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -1,26 +1,20 @@
 // TODO: For now, lib is symlinked to example to ease local development.
 // But the final plan is to provide a stub file once we know what the interface will be.
 
-
-use std::cell::Cell as MutCell;
-
 pub trait Cell<T> {
     fn value(&self) -> &T;
-    fn epoch(&self) -> usize;
 }
 
 pub struct Reactor;
 
 pub struct InputCell<T> {
     val: T,
-    epoch: usize,
 }
 
-pub struct Compute1Cell<'a, T: 'a, U: Copy, F: Fn(&T) -> U> {
+pub struct Compute1Cell<'a, T: 'a, U, F: Fn(&T) -> U> {
     compute: F,
     cell: &'a Cell<T>,
-    epoch: MutCell<usize>,
-    val: MutCell<U>,
+    val: U,
 }
 
 impl Reactor {
@@ -31,15 +25,14 @@ impl Reactor {
     pub fn create_input<T>(&self, initial: T) -> InputCell<T> {
         InputCell {
             val: initial,
-            epoch: 0,
         }
     }
 
-    pub fn create_compute1<'a, T, U: Copy, F: Fn(&T) -> U>(&self, cell: &'a Cell<T>, compute: F) -> Compute1Cell<'a, T, U, F> {
+    pub fn create_compute1<'a, T, U, F>(&self, cell: &'a Cell<T>, compute: F) -> Compute1Cell<'a, T, U, F>
+        where F: Fn(&T) -> U {
         Compute1Cell {
-            val: MutCell::new(compute(cell.value())),
+            val: compute(cell.value()),
             cell: cell,
-            epoch: MutCell::new(cell.epoch()),
             compute: compute,
         }
     }
@@ -49,10 +42,6 @@ impl <T> Cell<T> for InputCell<T> {
     fn value(&self) -> &T {
         &self.val
     }
-
-    fn epoch(&self) -> usize {
-        self.epoch
-    }
 }
 
 impl <T> InputCell<T> {
@@ -61,16 +50,8 @@ impl <T> InputCell<T> {
     }
 }
 
-impl <'a, T, U: Copy, F: Fn(&T) -> U> Cell<U> for Compute1Cell<'a, T, U, F> {
+impl <'a, T, U, F: Fn(&T) -> U> Cell<U> for Compute1Cell<'a, T, U, F> {
     fn value(&self) -> &U {
-        if self.epoch() < self.cell.epoch() {
-            self.epoch.set(self.cell.epoch());
-            self.val.set((self.compute)(self.cell.value()));
-        }
-        &self.val.get().clone()
-    }
-
-    fn epoch(&self) -> usize {
-        self.epoch.get()
+        &self.val
     }
 }

--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -1,0 +1,57 @@
+// TODO: For now, lib is symlinked to example to ease local development.
+// But the final plan is to provide a stub file once we know what the interface will be.
+
+pub trait Cell<T> {
+    fn value(&self) -> &T;
+}
+
+pub struct Reactor;
+
+pub struct InputCell<T> {
+    val: T,
+}
+
+pub struct Compute1Cell<'a, T: 'a, U, F: Fn(&T) -> U> {
+    compute: F,
+    cell: &'a Cell<T>,
+    val: U,
+}
+
+impl Reactor {
+    pub fn new() -> Reactor {
+        Reactor{}
+    }
+
+    pub fn create_input<T>(&self, initial: T) -> InputCell<T> {
+        InputCell {
+            val: initial,
+        }
+    }
+
+    pub fn create_compute1<'a, T, U, F>(&self, cell: &'a Cell<T>, compute: F) -> Compute1Cell<'a, T, U, F>
+        where F: Fn(&T) -> U {
+        Compute1Cell {
+            val: compute(cell.value()),
+            cell: cell,
+            compute: compute,
+        }
+    }
+}
+
+impl <T> Cell<T> for InputCell<T> {
+    fn value(&self) -> &T {
+        &self.val
+    }
+}
+
+impl <T> InputCell<T> {
+    pub fn set_value(&mut self, new_val: T) {
+        self.val = new_val;
+    }
+}
+
+impl <'a, T, U, F: Fn(&T) -> U> Cell<U> for Compute1Cell<'a, T, U, F> {
+    fn value(&self) -> &U {
+        &self.val
+    }
+}

--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -5,13 +5,7 @@ pub trait Cell<T> {
     fn value(&self) -> &T;
 }
 
-trait Propagatable {
-    fn propagate(&mut self);
-}
-
-pub struct Reactor {
-    cells: Vec<Box<Propagatable>>,
-}
+pub struct Reactor;
 
 pub struct InputCell<T> {
     val: T,
@@ -25,9 +19,7 @@ pub struct Compute1Cell<'a, T: 'a, U, F: Fn(&T) -> U> {
 
 impl Reactor {
     pub fn new() -> Reactor {
-        Reactor{
-            cells: Vec::new(),
-        }
+        Reactor{}
     }
 
     pub fn create_input<T>(&self, initial: T) -> InputCell<T> {
@@ -36,15 +28,13 @@ impl Reactor {
         }
     }
 
-    pub fn create_compute1<'a, T, U, F>(&mut self, cell: &'a Cell<T>, compute: F) -> Compute1Cell<'a, T, U, F>
+    pub fn create_compute1<'a, T, U, F>(&self, cell: &'a Cell<T>, compute: F) -> Compute1Cell<'a, T, U, F>
         where F: Fn(&T) -> U {
-        let cell = Compute1Cell {
+        Compute1Cell {
             val: compute(cell.value()),
             cell: cell,
             compute: compute,
-        };
-        self.cells.push(Box::new(cell));
-        cell
+        }
     }
 }
 
@@ -63,11 +53,5 @@ impl <T> InputCell<T> {
 impl <'a, T, U, F: Fn(&T) -> U> Cell<U> for Compute1Cell<'a, T, U, F> {
     fn value(&self) -> &U {
         &self.val
-    }
-}
-
-impl <'a, T, U, F: Fn(&T) -> U> Propagatable for Compute1Cell<'a, T, U, F> {
-    fn propagate(&mut self) {
-        self.val = (self.compute)(self.cell.value());
     }
 }

--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -52,6 +52,6 @@ impl <T> InputCell<T> {
 
 impl <'a, T, U, F: Fn(&T) -> U> Cell<U> for Compute1Cell<'a, T, U, F> {
     fn value(&self) -> &U {
-        &(self.compute)(self.cell.value())
+        &self.val
     }
 }

--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -52,6 +52,6 @@ impl <T> InputCell<T> {
 
 impl <'a, T, U, F: Fn(&T) -> U> Cell<U> for Compute1Cell<'a, T, U, F> {
     fn value(&self) -> &U {
-        &self.val
+        &(self.compute)(self.cell.value())
     }
 }

--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -1,20 +1,26 @@
 // TODO: For now, lib is symlinked to example to ease local development.
 // But the final plan is to provide a stub file once we know what the interface will be.
 
+
+use std::cell::Cell as MutCell;
+
 pub trait Cell<T> {
     fn value(&self) -> &T;
+    fn epoch(&self) -> usize;
 }
 
 pub struct Reactor;
 
 pub struct InputCell<T> {
     val: T,
+    epoch: usize,
 }
 
-pub struct Compute1Cell<'a, T: 'a, U, F: Fn(&T) -> U> {
+pub struct Compute1Cell<'a, T: 'a, U: Copy, F: Fn(&T) -> U> {
     compute: F,
     cell: &'a Cell<T>,
-    val: U,
+    epoch: MutCell<usize>,
+    val: MutCell<U>,
 }
 
 impl Reactor {
@@ -25,14 +31,15 @@ impl Reactor {
     pub fn create_input<T>(&self, initial: T) -> InputCell<T> {
         InputCell {
             val: initial,
+            epoch: 0,
         }
     }
 
-    pub fn create_compute1<'a, T, U, F>(&self, cell: &'a Cell<T>, compute: F) -> Compute1Cell<'a, T, U, F>
-        where F: Fn(&T) -> U {
+    pub fn create_compute1<'a, T, U: Copy, F: Fn(&T) -> U>(&self, cell: &'a Cell<T>, compute: F) -> Compute1Cell<'a, T, U, F> {
         Compute1Cell {
-            val: compute(cell.value()),
+            val: MutCell::new(compute(cell.value())),
             cell: cell,
+            epoch: MutCell::new(cell.epoch()),
             compute: compute,
         }
     }
@@ -42,6 +49,10 @@ impl <T> Cell<T> for InputCell<T> {
     fn value(&self) -> &T {
         &self.val
     }
+
+    fn epoch(&self) -> usize {
+        self.epoch
+    }
 }
 
 impl <T> InputCell<T> {
@@ -50,8 +61,16 @@ impl <T> InputCell<T> {
     }
 }
 
-impl <'a, T, U, F: Fn(&T) -> U> Cell<U> for Compute1Cell<'a, T, U, F> {
+impl <'a, T, U: Copy, F: Fn(&T) -> U> Cell<U> for Compute1Cell<'a, T, U, F> {
     fn value(&self) -> &U {
-        &self.val
+        if self.epoch() < self.cell.epoch() {
+            self.epoch.set(self.cell.epoch());
+            self.val.set((self.compute)(self.cell.value()));
+        }
+        &self.val.get().clone()
+    }
+
+    fn epoch(&self) -> usize {
+        self.epoch.get()
     }
 }

--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -1,57 +1,68 @@
 // TODO: For now, lib is symlinked to example to ease local development.
 // But the final plan is to provide a stub file once we know what the interface will be.
 
-pub trait Cell<T> {
-    fn value(&self) -> &T;
-}
+pub type CellID = usize;
 
-pub struct Reactor;
-
-pub struct InputCell<T> {
+pub struct Cell<'a, T: Copy> {
     val: T,
+    dependents: Vec<CellID>,
+    cell_type: CellType<'a, T>,
 }
 
-pub struct Compute1Cell<'a, T: 'a, U, F: Fn(&T) -> U> {
-    compute: F,
-    cell: &'a Cell<T>,
-    val: U,
+pub enum CellType<'a, T: Copy> {
+    Input,
+    Compute(Vec<CellID>, Box<Fn(&[T]) -> T + 'a>),
 }
 
-impl Reactor {
-    pub fn new() -> Reactor {
-        Reactor{}
+pub struct Reactor<'a, T: Copy> {
+    cells: Vec<Cell<'a, T>>,
+}
+
+impl <'a, T: Copy> Reactor<'a, T> {
+    pub fn new() -> Self {
+        Reactor{
+            cells: Vec::new(),
+        }
     }
 
-    pub fn create_input<T>(&self, initial: T) -> InputCell<T> {
-        InputCell {
+    pub fn create_input(&mut self, initial: T) -> CellID {
+        self.cells.push(Cell {
             val: initial,
-        }
+            dependents: Vec::new(),
+            cell_type: CellType::Input,
+        });
+        self.cells.len() - 1
     }
 
-    pub fn create_compute1<'a, T, U, F>(&self, cell: &'a Cell<T>, compute: F) -> Compute1Cell<'a, T, U, F>
-        where F: Fn(&T) -> U {
-        Compute1Cell {
-            val: compute(cell.value()),
-            cell: cell,
-            compute: compute,
-        }
+    pub fn create_compute<F: Fn(&[T]) -> T + 'a>(&mut self, dependencies: &[CellID], compute_func: F) -> CellID {
+        let inputs: Vec<_> = dependencies.iter().map(|&id| self.get(id).unwrap().value()).collect();
+        let initial = compute_func(&inputs);
+        self.cells.push(Cell {
+            val: initial,
+            dependents: Vec::new(),
+            cell_type: CellType::Compute(dependencies.iter().cloned().collect(), Box::new(compute_func)),
+        });
+        self.cells.len() - 1
+    }
+
+    pub fn get(&self, id: CellID) -> Option<&Cell<'a, T>> {
+        self.cells.get(id)
+    }
+
+    pub fn get_mut(&mut self, id: CellID) -> Option<&mut Cell<'a, T>> {
+        self.cells.get_mut(id)
     }
 }
 
-impl <T> Cell<T> for InputCell<T> {
-    fn value(&self) -> &T {
-        &self.val
+impl <'a, T: Copy> Cell<'a, T> {
+    pub fn value(&self) -> T {
+        self.val
     }
-}
 
-impl <T> InputCell<T> {
     pub fn set_value(&mut self, new_val: T) {
-        self.val = new_val;
-    }
-}
-
-impl <'a, T, U, F: Fn(&T) -> U> Cell<U> for Compute1Cell<'a, T, U, F> {
-    fn value(&self) -> &U {
-        &self.val
+        match self.cell_type {
+            CellType::Input => self.val = new_val,
+            CellType::Compute(_, _) => panic!("Can't set compute value directly"),
+        }
     }
 }

--- a/exercises/react/src/lib.rs
+++ b/exercises/react/src/lib.rs
@@ -1,0 +1,1 @@
+../example.rs

--- a/exercises/react/src/lib.rs
+++ b/exercises/react/src/lib.rs
@@ -12,7 +12,7 @@ pub struct Reactor<T> {
 }
 
 // You are guaranteed that Reactor will only be tested against types that are Copy + PartialEq.
-impl <'a, T: Copy + PartialEq> Reactor<T> {
+impl <T: Copy + PartialEq> Reactor<T> {
     pub fn new() -> Self {
         unimplemented!()
     }
@@ -33,7 +33,7 @@ impl <'a, T: Copy + PartialEq> Reactor<T> {
     // Notice that there is no way to *remove* a cell.
     // This means that you may assume, without checking, that if the dependencies exist at creation
     // time they will continue to exist as long as the Reactor exists.
-    pub fn create_compute<F: Fn(&[T]) -> T + 'a>(&mut self, dependencies: &[CellID], compute_func: F) -> Result<CellID, ()> {
+    pub fn create_compute<F: Fn(&[T]) -> T>(&mut self, dependencies: &[CellID], compute_func: F) -> Result<CellID, ()> {
         unimplemented!()
     }
 
@@ -73,7 +73,7 @@ impl <'a, T: Copy + PartialEq> Reactor<T> {
     // * Exactly once if the compute cell's value changed as a result of the set_value call.
     //   The value passed to the callback should be the final value of the compute cell after the
     //   set_value call.
-    pub fn add_callback<F: FnMut(T) -> () + 'a>(&mut self, id: CellID, callback: F) -> Result<CallbackID, ()> {
+    pub fn add_callback<F: FnMut(T) -> ()>(&mut self, id: CellID, callback: F) -> Result<CallbackID, ()> {
         unimplemented!()
     }
 

--- a/exercises/react/src/lib.rs
+++ b/exercises/react/src/lib.rs
@@ -1,1 +1,91 @@
-../example.rs
+#[allow(unused_variables)]
+
+// Because these are passed without & to some functions,
+// it will probably be necessary for these two types to be Copy.
+pub type CellID = ();
+pub type CallbackID = ();
+
+pub struct Reactor<T> {
+    // Just so that the compiler doesn't complain about an unused type parameter.
+    // You probably want to delete this field.
+    dummy: T,
+}
+
+// You are guaranteed that Reactor will only be tested against types that are Copy + PartialEq.
+impl <'a, T: Copy + PartialEq> Reactor<T> {
+    pub fn new() -> Self {
+        unimplemented!()
+    }
+
+    // Creates an input cell with the specified initial value, returning its ID.
+    pub fn create_input(&mut self, initial: T) -> CellID {
+        unimplemented!()
+    }
+
+    // Creates a compute cell with the specified dependencies and compute function.
+    // The compute function is expected to take in its arguments in the same order as specified in
+    // `dependencies`.
+    // You do not need to reject compute functions that expect more arguments than there are
+    // dependencies (how would you check for this, anyway?).
+    //
+    // Return an Err (and you can change the error type) if any dependency doesn't exist.
+    //
+    // Notice that there is no way to *remove* a cell.
+    // This means that you may assume, without checking, that if the dependencies exist at creation
+    // time they will continue to exist as long as the Reactor exists.
+    pub fn create_compute<F: Fn(&[T]) -> T + 'a>(&mut self, dependencies: &[CellID], compute_func: F) -> Result<CellID, ()> {
+        unimplemented!()
+    }
+
+    // Retrieves the current value of the cell, or None if the cell does not exist.
+    //
+    // You may wonder whether it is possible to implement `get(&self, id: CellID) -> Option<&Cell>`
+    // and have a `value(&self)` method on `Cell`.
+    //
+    // It turns out this introduces a significant amount of extra complexity to this exercise.
+    // We chose not to cover this here, since this exercise is probably enough work as-is.
+    pub fn value(&self, id: CellID) -> Option<T> {
+        unimplemented!()
+    }
+
+    // Sets the value of the specified input cell.
+    //
+    // Return an Err (and you can change the error type) if the cell does not exist, or the
+    // specified cell is a compute cell, since compute cells cannot have their values directly set.
+    //
+    // Similarly, you may wonder about `get_mut(&mut self, id: CellID) -> Option<&mut Cell>`, with
+    // a `set_value(&mut self, new_value: T)` method on `Cell`.
+    //
+    // As before, that turned out to add too much extra complexity.
+    pub fn set_value(&mut self, id: CellID, new_value: T) -> Result<(), ()> {
+        unimplemented!()
+    }
+
+    // Adds a callback to the specified compute cell.
+    //
+    // Return an Err (and you can change the error type) if the cell does not exist.
+    //
+    // Callbacks on input cells will not be tested.
+    //
+    // The semantics of callbacks (as will be tested):
+    // For a single set_value call, each compute cell's callbacks should each be called:
+    // * Zero times if the compute cell's value did not change as a result of the set_value call.
+    // * Exactly once if the compute cell's value changed as a result of the set_value call.
+    //   The value passed to the callback should be the final value of the compute cell after the
+    //   set_value call.
+    pub fn add_callback<F: FnMut(T) -> () + 'a>(&mut self, id: CellID, callback: F) -> Result<CallbackID, ()> {
+        unimplemented!()
+    }
+
+    // Removes the specified callback, using an ID returned from add_callback.
+    //
+    // Return an Err (and you can change the error type) if the cell does not exist.
+    //
+    // If the callback does not exist (or has already been removed), it is up to you whether to
+    // return Ok(()) or an error. This should not interfere with other callbacks.
+    //
+    // A removed callback should no longer be called.
+    pub fn remove_callback(&mut self, cell: CellID, callback: CallbackID) -> Result<(), ()> {
+        unimplemented!()
+    }
+}

--- a/exercises/react/src/lib.rs
+++ b/exercises/react/src/lib.rs
@@ -79,10 +79,8 @@ impl <T: Copy + PartialEq> Reactor<T> {
 
     // Removes the specified callback, using an ID returned from add_callback.
     //
-    // Return an Err (and you can change the error type) if the cell does not exist.
-    //
-    // If the callback does not exist (or has already been removed), it is up to you whether to
-    // return Ok(()) or an error. This should not interfere with other callbacks.
+    // Return an Err (and you can change the error type) if either the cell or callback
+    // does not exist.
     //
     // A removed callback should no longer be called.
     pub fn remove_callback(&mut self, cell: CellID, callback: CallbackID) -> Result<(), ()> {

--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -20,6 +20,14 @@ fn an_input_cells_value_can_be_set() {
 
 #[test]
 #[ignore]
+fn error_setting_a_nonexistent_input_cell() {
+    let mut dummy_reactor = Reactor::new();
+    let input = dummy_reactor.create_input(1);
+    assert!(Reactor::new().set_value(input, 0).is_err());
+}
+
+#[test]
+#[ignore]
 fn compute_cells_calculate_initial_value() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
@@ -35,6 +43,14 @@ fn compute_cells_take_inputs_in_the_right_order() {
     let two = reactor.create_input(2);
     let output = reactor.create_compute(&vec![one, two], |v| v[0] + v[1] * 10).unwrap();
     assert_eq!(reactor.value(output).unwrap(), 21);
+}
+
+#[test]
+#[ignore]
+fn error_creating_compute_cell_if_input_doesnt_exist() {
+    let mut dummy_reactor = Reactor::new();
+    let input = dummy_reactor.create_input(1);
+    assert!(Reactor::new().create_compute(&vec![input], |_| 0).is_err());
 }
 
 #[test]
@@ -63,6 +79,15 @@ fn compute_cells_can_depend_on_other_compute_cells() {
 
 #[test]
 #[ignore]
+fn error_setting_a_compute_cell() {
+    let mut reactor = Reactor::new();
+    let input = reactor.create_input(1);
+    let output = reactor.create_compute(&vec![input], |_| 0).unwrap();
+    assert!(reactor.set_value(output, 3).is_err());
+}
+
+#[test]
+#[ignore]
 fn compute_cells_fire_callbacks() {
     // This is a bit awkward, but the closure mutably borrows `values`.
     // So we have to end its borrow by taking reactor out of scope.
@@ -75,6 +100,15 @@ fn compute_cells_fire_callbacks() {
         assert!(reactor.set_value(input, 3).is_ok());
     }
     assert_eq!(values, vec![4]);
+}
+
+#[test]
+#[ignore]
+fn error_adding_callback_to_nonexistent_cell() {
+    let mut dummy_reactor = Reactor::new();
+    let input = dummy_reactor.create_input(1);
+    let output = dummy_reactor.create_compute(&vec![input], |_| 0).unwrap();
+    assert!(Reactor::new().add_callback(output, |_: usize| println!("hi")).is_err());
 }
 
 #[test]

--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -1,26 +1,34 @@
 extern crate react;
 
+use std::fmt::Debug;
+
 #[allow(unused_mut)]
 
 // TODO: [ignore] tests
 
 use react::*;
 
+fn assert_cell_value<'a, T: Copy + PartialEq + Debug>(reactor: &Reactor<'a, T>, id: CellID, expected: T) {
+    let cell = reactor.get(id).unwrap();
+    assert_eq!(cell.value(), expected);
+}
+
 #[test]
 fn set_value_of_input() {
     let mut reactor = Reactor::new();
-    let mut input = reactor.create_input(1);
-    assert_eq!(*input.value(), 1);
-    input.set_value(2);
-    assert_eq!(*input.value(), 2);
+    let input = reactor.create_input(1);
+    assert_cell_value(&reactor, input, 1);
+    {
+        let mut cell = reactor.get_mut(input).unwrap();
+        cell.set_value(2);
+    }
+    assert_cell_value(&reactor, input, 2);
 }
 
 #[test]
 fn compute1_depending_on_input() {
     let mut reactor = Reactor::new();
-    let mut input = reactor.create_input(1);
-    let output = reactor.create_compute1(&input, |v| v + 1);
-    assert_eq!(*output.value(), 2);
-    //input.set_value(2);
-    //assert_eq!(*output.value(), 3);
+    let input = reactor.create_input(1);
+    let output = reactor.create_compute(&vec![input], |v| v[0] + 1);
+    assert_cell_value(&reactor, output, 2);
 }

--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -1,0 +1,26 @@
+extern crate react;
+
+#[allow(unused_mut)]
+
+// TODO: [ignore] tests
+
+use react::*;
+
+#[test]
+fn set_value_of_input() {
+    let mut reactor = Reactor::new();
+    let mut input = reactor.create_input(1);
+    assert_eq!(*input.value(), 1);
+    input.set_value(2);
+    assert_eq!(*input.value(), 2);
+}
+
+#[test]
+fn compute1_depending_on_input() {
+    let mut reactor = Reactor::new();
+    let mut input = reactor.create_input(1);
+    let output = reactor.create_compute1(&input, |v| v + 1);
+    assert_eq!(*output.value(), 2);
+    //input.set_value(2);
+    //assert_eq!(*output.value(), 3);
+}

--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -162,7 +162,7 @@ fn removing_a_callback_multiple_times_doesnt_interfere_with_other_callbacks() {
         // We want the first remove to be Ok, but we don't care about the others.
         assert!(reactor.remove_callback(output, callback).is_ok());
         for _ in 1..5 {
-            let _ = reactor.remove_callback(output, callback);
+            assert!(reactor.remove_callback(output, callback).is_err());
         }
         assert!(reactor.set_value(input, 2).is_ok());
     }

--- a/problems.md
+++ b/problems.md
@@ -75,3 +75,4 @@ parallel-letter-frequency | multi-threading
 rectangles |  Enum, structs, traits, Lifetimes
 forth |  Parser reimplementation
 circular-buffer |  Buffer reimplementation, Generics
+react |  TODO

--- a/problems.md
+++ b/problems.md
@@ -75,4 +75,4 @@ parallel-letter-frequency | multi-threading
 rectangles |  Enum, structs, traits, Lifetimes
 forth |  Parser reimplementation
 circular-buffer |  Buffer reimplementation, Generics
-react |  TODO
+react |  Lifetimes, generics, closures


### PR DESCRIPTION
I felt it would be educational for me to try to implement this in Rust.

Edit: After completing it: Very much so. Lifetimes, closures, storing closure in structs (you have to be generic over the closure type, and give it a lifetime, also understand FnMut vs Fn)

Tests will be taken from the Go track. In case you wonder why there isn't a JSON file... the JSON file for this problem probably at best can only have rough descriptions of how the tests should go.

~~In some instances, I am unsure of the API that should be presented to students. When I am unsure, I will solicit feedback. After that, I'll make a stub file.~~

Edit after having attempted the problem many ways: I'm pretty sure this interface is simple and works. Whereas an interface that gives direct access to the cells is fraught with problems. You can see some failed attempts in the commit history.

Reviewers, please pay attention to the following questions. I am satisfied with my current answer to all of them, but would gratefully accept ideas on them.

- API OK, with value and set_value? My ideal is actually get and get_mut as I noted in the stub files, but I attempted and failed to implement such an API. If any can provide an implementation for get and get_mut I strongly gladly using it and making that the API.
- [Any way to remove the requirement of Copy?](https://github.com/exercism/xrust/pull/191#discussion_r77243451) I tried and failed, and I honestly don't think it's worth it, but  maybe you think differently!
- [Any way to shorten the amount of time that the test callbacks borrow the vectors they write into?](https://github.com/exercism/xrust/pull/191#issuecomment-244187037) I didn't see any so I'm satisfied with the current implementation, but maybe someone else has one.
- Does anyone care whether `remove_callback` on an already-removed callback should be `Ok` or `Err`? I simply didn't test the exact result, only that it doesn't interfere with other callbacks.
- Should we keep the reactor generic over the type it reacts on, or go back to just ints like the other tracks? However, even if we go back to ints the interface still has to use generics for the `Fn` and `FnMut`, so we can't avoid them completely. But maybe we want to decrease the amount of work required as much as we can.