### PR TITLE
hexadecimal: use enumerate() instead of zip(positions)

### DIFF
--- a/exercises/hexadecimal/example.rs
+++ b/exercises/hexadecimal/example.rs
@@ -22,15 +22,14 @@ fn parse_hex_digit(c: char) -> Option<i64> {
 
 pub fn hex_to_int(string: &str) -> Option<i64> {
     let base: i64 = 16;
-    let positions = 0 .. string.len() as u32;
 
     string
         .chars()
         .rev()
-        .zip(positions)
-        .fold(Some(0), |acc, (c, pos)| {
+        .enumerate()
+        .fold(Some(0), |acc, (pos, c)| {
             parse_hex_digit(c).and_then(|n| {
-                acc.map(|acc| acc + n * base.pow(pos))
+                acc.map(|acc| acc + n * base.pow(pos as u32))
             })
         })
 }


### PR DESCRIPTION
Since there is already a common idiom to use for iterate with index, we
should use it instead of a custom one.

Impact is fairly invisible since hexadecimal has been deprecated, but
still useful for anyone who glances at this code using the repo.