### PR TITLE
An equilateral triangle is a special case of an isosceles triangle.

### DIFF
--- a/exercises/triangle/tests/triangle.rs
+++ b/exercises/triangle/tests/triangle.rs
@@ -23,7 +23,7 @@ fn equilateral_triangles_have_equal_sides() {
     let sides = [2, 2, 2];
     let triangle = Triangle::build(sides).unwrap();
     assert!(triangle.is_equilateral());
-    assert!(!triangle.is_isosceles());
+    assert!(triangle.is_isosceles());
     assert!(!triangle.is_scalene());
 }
 
@@ -33,7 +33,7 @@ fn larger_equilateral_triangles_have_equal_sides() {
     let sides = [10, 10, 10];
     let triangle = Triangle::build(sides).unwrap();
     assert!(triangle.is_equilateral());
-    assert!(!triangle.is_isosceles());
+    assert!(triangle.is_isosceles());
     assert!(!triangle.is_scalene());
 }
 


### PR DESCRIPTION
An isosceles triangle is a triangle with (at least) two equal sides. A triangle with all sides equal is called an equilateral triangle, and a triangle with no sides equal is called a scalene triangle. An equilateral triangle is therefore a special case of an isosceles triangle having not just two, but all three sides and angles equal.

http://mathworld.wolfram.com/IsoscelesTriangle.html