### PR TITLE
Bug fix for the last test of `Allergies`

### DIFF
--- a/exercises/allergies/tests/allergies.rs
+++ b/exercises/allergies/tests/allergies.rs
@@ -128,6 +128,7 @@ fn allergic_to_everything() {
 #[ignore]
 fn scores_over_255_do_not_trigger_false_positives() {
     let expected = vec![Allergen::Eggs,
+                        Allergen::Peanuts,
                         Allergen::Shellfish,
                         Allergen::Strawberries,
                         Allergen::Tomatoes,


### PR DESCRIPTION
The last test must not contains false positives, but 509 is greater than 255 so `expected` must contain `Allergen::Peanuts`.