### PR TITLE
Fixes issue #194.

### DIFF
--- a/exercises/hamming/tests/hamming.rs
+++ b/exercises/hamming/tests/hamming.rs
@@ -1,42 +1,42 @@
-extern crate hamming as dna;
+extern crate hamming;
 
 #[test]
 fn test_no_difference_between_empty_strands() {
-    assert_eq!(dna::hamming_distance("", "").unwrap(), 0);
+    assert_eq!(hamming::hamming_distance("", "").unwrap(), 0);
 }
 
 #[test]
 #[ignore]
 fn test_no_difference_between_identical_strands() {
-    assert_eq!(dna::hamming_distance("GGACTGA", "GGACTGA").unwrap(), 0);
+    assert_eq!(hamming::hamming_distance("GGACTGA", "GGACTGA").unwrap(), 0);
 }
 
 #[test]
 #[ignore]
 fn test_complete_hamming_distance_in_small_strand() {
-    assert_eq!(dna::hamming_distance("ACT", "GGA").unwrap(), 3);
+    assert_eq!(hamming::hamming_distance("ACT", "GGA").unwrap(), 3);
 }
 
 #[test]
 #[ignore]
 fn test_small_hamming_distance_in_the_middle_somewhere() {
-    assert_eq!(dna::hamming_distance("GGACG", "GGTCG").unwrap(), 1);
+    assert_eq!(hamming::hamming_distance("GGACG", "GGTCG").unwrap(), 1);
 }
 
 #[test]
 #[ignore]
 fn test_larger_distance() {
-    assert_eq!(dna::hamming_distance("ACCAGGG", "ACTATGG").unwrap(), 2);
+    assert_eq!(hamming::hamming_distance("ACCAGGG", "ACTATGG").unwrap(), 2);
 }
 
 #[test]
 #[ignore]
 fn test_first_string_is_longer() {
-    assert!(dna::hamming_distance("AAA", "AA").is_err());
+    assert!(hamming::hamming_distance("AAA", "AA").is_err());
 }
 
 #[test]
 #[ignore]
 fn test_second_string_is_longer() {
-    assert!(dna::hamming_distance("A", "AA").is_err());
+    assert!(hamming::hamming_distance("A", "AA").is_err());
 }


### PR DESCRIPTION
This fixes issue #194 as the unnecessary alias
`extern crate hamming as dna`
is shortened to just the extern crate statement along with the then necessary changes to the used module name in the asserts.