### PR TITLE
attribute the rust icon (moved here from exercism.io)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Please see the [contributing guide](https://github.com/exercism/x-api/blob/maste
 The MIT License (MIT)
 
 Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
+
+## Rust icon
+The Rust Logo is created by the Mozilla Corporation, and has been released under the Creative Commons Attribution 4.0 International license.
+We tweaked the color from black to charcoal (#212121).


### PR DESCRIPTION
a step in fixing https://github.com/exercism/exercism.io/issues/3112.