### PR TITLE
README: Link to Creative Commons license

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ The MIT License (MIT)
 Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
 
 ## Rust icon
-The Rust Logo is created by the Mozilla Corporation, and has been released under the Creative Commons Attribution 4.0 International license.
+The Rust Logo is created by the Mozilla Corporation, and has been released under the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/).
 We tweaked the color from black to charcoal (#212121).


### PR DESCRIPTION
As of #214 we now have attribution for our icon. By the terms of the
license, we must provide a link to the license. Let's comply.