### PR TITLE
acronym: Add GIMP case

### DIFF
--- a/exercises/acronym/tests/acronym.rs
+++ b/exercises/acronym/tests/acronym.rs
@@ -31,6 +31,12 @@ fn all_caps_words() {
 
 #[test]
 #[ignore]
+fn non_acronym_all_caps_word() {
+    assert_eq!(acronym::abbreviate("GNU Image Manipulation Program"), "GIMP");
+}
+
+#[test]
+#[ignore]
 fn hyphenated() {
     assert_eq!(acronym::abbreviate("Complementary metal-oxide semiconductor"), 
                "CMOS");


### PR DESCRIPTION
Added in https://github.com/exercism/x-common/pull/405

The "PHP: Hypertext Preprocessor -> PHP" case made it unclear whether
the reason the answer is "PHP" is because it's the first acronym in the
word, or because it's the first letter of each word.
To disambiguate, we add "GNU Image Manipulation Program -> GIMP", which
makes it clear that the answer is not GNU.