### PR TITLE
bowling: propose tests for err semantics

### DIFF
--- a/exercises/bowling/tests/bowling.rs
+++ b/exercises/bowling/tests/bowling.rs
@@ -90,6 +90,38 @@ fn ten_frames_without_a_strike_or_spare() {
 
 #[test]
 #[ignore]
+fn too_many_pins_in_single_roll_does_not_prevent_future_ok_rolls() {
+    let mut game = BowlingGame::new();
+
+    assert!(game.roll(11).is_err());
+    assert!(game.roll(5).is_ok());
+
+    for _ in 0..19 {
+        let _ = game.roll(0);
+    }
+
+    assert_eq!(game.score().unwrap(), 5);
+}
+
+#[test]
+#[ignore]
+fn too_many_pins_in_consecutive_rolls_does_not_prevent_future_ok_rolls() {
+    let mut game = BowlingGame::new();
+
+    assert!(game.roll(5).is_ok());
+    assert!(game.roll(6).is_err());
+    assert!(game.roll(4).is_ok());
+
+    for _ in 0..9 {
+        let _ = game.roll(0);
+        let _ = game.roll(0);
+    }
+
+    assert_eq!(game.score().unwrap(), 9);
+}
+
+#[test]
+#[ignore]
 fn spare_in_the_first_frame_followed_by_zeros() {
     let mut game = BowlingGame::new();
 


### PR DESCRIPTION
Specifically: if a call to `roll()` is made that results in an error,
**the game state should not be altered**, so that future calls to
`roll()` will proceed as if the erroneous roll **never happened**.

This is only a proposal because there was doubt in #213 about whether
they should be added.

Since it was suggested, after seeing it in my Exercism submission, that
I open an issue for it, I will, because I can let code speak to
accompany my words.

Right now there's no good way to express this kind of semantics in
x-common, but maybe a general discussion on it would be OK to brainstorm
some ways to do it.

TODO:

* The current example solution needs to be fixed.
* It is possible we can add more tests of this type - basically any time
  we expect an `is_err()` from a roll.

I would only want to put in the work to proceed with these if we decide
we *do* want these kinds of tests.