### PR TITLE
Use example.rs specific Cargo.toml file during CI

### DIFF
--- a/_test/check-exercises.sh
+++ b/_test/check-exercises.sh
@@ -28,6 +28,11 @@ for exercise in exercises/*/tests; do
         [ -d src ] || mkdir src
         cp example.rs src/lib.rs
 
+        # Overwrite empty Cargo.toml if an example specific file exists
+        if [ -f Cargo-example.toml ]; then
+            cp Cargo-example.toml Cargo.toml
+        fi
+
         # Forcibly strip all "ignore" statements from the testing files
         for test in tests/*.rs; do
             sed -i '/\[ignore\]/d' $test


### PR DESCRIPTION
Add support for optional `Cargo-example.toml` files to satisfy the CI and do not pollute the empty project config file. See discussion in #225

One thing I could not figure out though: where is it defined what files the CLI tool will download? Do I have to modify anything else to prevent the download of `Cargo-examle.toml`? 