### PR TITLE
Update language docs

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,3 @@
 ## Installation
 
-Follow the ["Getting Started" chapter in the Rust book](https://doc.rust-lang.org/book/getting-started.html).
+Methods for installing Rust change as the language evolves. To get up-to-date installation instructions head to the [Rust homepage](https://www.rust-lang.org/) and click the "Install Rust" link.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,16 +1,8 @@
 ## Writing the Code
 
-Write your code in `src/lib.rs`
+Write your code in `src/lib.rs`. Some exercises come with a stub file in `src/lib.rs` that will show you the signatures of the code you'll need to write. If the exercise does not come with a `src/lib.rs` file, create one.
 
-You'll be writing a *library crate*.  Code for a crate is stored within the `src/` subdirectory.  *Library crates* must contain at least a file named `lib.rs`.  For more details, check out the rustlang book [chapter on crates and modules](http://doc.rust-lang.org/stable/book/crates-and-modules.html)
-
-If you were starting from scratch you could use `cargo new` to create the filestructure: e.g. `cargo new $projectname`.
-exercism has already created the projectname directory so you'll need to create `src/lib.rs` manually:
-
-```bash
-mkdir src
-touch src/lib.rs
-```
+The directory must be named `src` and the file must be named `lib.rs` otherwise your code will not compile. For more details, check out the rustlang book [chapter on crates and modules](http://doc.rust-lang.org/stable/book/crates-and-modules.html)
 
 ### Running Tests
 
@@ -24,3 +16,4 @@ Only the first test is enabled by default.  After you are ready to pass the next
 
 You should try to write as little code possible to get the tests to pass.  Let the test failures guide you to what should be written next.
 
+Because Rust checks all code at compile time you may find that your tests won't compile until you write the required code. Even `ignore`d tests are checked at compile time. You can [comment out](https://doc.rust-lang.org/stable/book/comments.html) tests that won't compile by starting each line with a `//`. Then, when you're ready to work on that test, you can un-comment it.


### PR DESCRIPTION
Fixes #232

- Update the installation directions to point people to the main page.
This has a few advantages to the other link:

1. It will take them to a language-localized page, if available.
2. It will give them a OS-specific install link.
3. It's kept more up-to-date than The Book.

- Update tests doc

Some of the changes here are just little edits. And I'm mentioning that
some exercises now come with a stub file is `src/lib.rs`.

The compilation errors generated by ignored tests is a frequent source
of confusion, I think. So I documented the easiest way around it,
commenting out the tests.