### PR TITLE
parallel-letter-frequency: Use &str with lifetime, not String

### DIFF
--- a/exercises/parallel-letter-frequency/example.rs
+++ b/exercises/parallel-letter-frequency/example.rs
@@ -5,20 +5,18 @@ use std::sync::mpsc::channel;
 
 /// Compute the frequency of each letter (technically of each unicode codepoint) using the given
 /// number of worker threads.
-pub fn frequency(texts: &[&str], num_workers: usize) -> HashMap<char, usize> {
+pub fn frequency(texts: &[&'static str], num_workers: usize) -> HashMap<char, usize> {
     assert!(num_workers > 0);
     let part_size_floor = texts.len() / num_workers;
     let rem = texts.len() % num_workers;
     let part_size = if rem > 0 { part_size_floor + 1 } else { part_size_floor };
-    let mut parts: Vec<Vec<String>> = Vec::with_capacity(part_size);
+    let mut parts: Vec<Vec<&str>> = Vec::with_capacity(part_size);
     for _ in 0 .. num_workers {
         parts.push(Vec::with_capacity(part_size));
     }
     let mut i = 0;
-    for line in texts.iter() {
-        // We'll need to clone those strings in order to satisfy some lifetime guarantees. Basically
-        // it's hard for the system to be sure that the threads spawned don't outlive the strings.
-        parts[i].push(line.to_string());
+    for &line in texts.iter() {
+        parts[i].push(line);
         i = (i + 1) % num_workers;
     }
 
@@ -41,7 +39,7 @@ pub fn frequency(texts: &[&str], num_workers: usize) -> HashMap<char, usize> {
     results
 }
 
-fn count(lines: Vec<String>) -> HashMap<char, usize> {
+fn count(lines: Vec<&str>) -> HashMap<char, usize> {
     let mut results: HashMap<char, usize> = HashMap::new();
     for line in lines.iter() {
         for c in line.chars() {

--- a/exercises/parallel-letter-frequency/tests/parallel-letter-frequency.rs
+++ b/exercises/parallel-letter-frequency/tests/parallel-letter-frequency.rs
@@ -42,6 +42,13 @@ fn test_no_texts() {
 
 #[test]
 #[ignore]
+fn test_hello_world() {
+    let hi = format!("Hello, {}!", "world");
+    frequency::frequency(&[&hi], 4);
+}
+
+#[test]
+#[ignore]
 fn test_one_letter() {
     let mut hm = HashMap::new();
     hm.insert('a', 1);


### PR DESCRIPTION
The previous version had a comment that explained a need for copying the
`&str` into `String`s, but this can be avoided.

The disadvantage is now that this function can *only* be invoked with
`&'static str`, which means that it can't (for example) accept arbitrary
user input as part of a command-line program. So it works for our style
of testing (all our tests do indeed use `&'static str`) but is
unrealistic code.

---

Reviewers should consider the disadvantage carefully before deciding whether to merge. Of course, this is only the example and doesn't affect the test code. On the other hand, it could be better to keep the example code realistic.

In the extreme case, we might even choose to add a test that creates non-`'static` strings, so that using `&'static str` is not possible (I do not advocate for this, but y'all can if you like)