### PR TITLE
travis: Test in release mode

### DIFF
--- a/_test/check-exercises.sh
+++ b/_test/check-exercises.sh
@@ -49,7 +49,7 @@ for exercise in exercises/*/tests; do
             cargo test --quiet --no-run
         else
             # Run the test and get the status
-            cargo test
+            cargo test --release
         fi
     )
 


### PR DESCRIPTION
Alphametics is unbearably slow in debug mode.

---

Reviewers should verify that there is a runtime improvement before merging. I was personally worried about whether `--release` would increase compile times for all exercises while only benefitting alphametics.