### PR TITLE
Benchmark parallel-letter-frequency. Closes #244

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ env:
   - DENYWARNINGS=
   - DENYWARNINGS=1
 matrix:
+  include:
+    - rust: nightly
+      env: BENCHMARK=1
+      script: "./_test/check-exercises.sh"
   allow_failures:
     - rust: nightly
     - rust: beta

--- a/_test/check-exercises.sh
+++ b/_test/check-exercises.sh
@@ -6,6 +6,12 @@ if [ -z "$DENYWARNINGS" ]; then
     set -e
 fi
 
+if [ -n "$BENCHMARK" ]; then
+    files=exercises/*/benches
+else
+    files=exercises/*/tests
+fi
+
 tmp=${TMPDIR:-/tmp/}
 mkdir "${tmp}exercises"
 
@@ -13,7 +19,7 @@ exitcode=0
 
 # An exercise worth testing is defined here as any top level directory with
 # a 'tests' directory
-for exercise in exercises/*/tests; do
+for exercise in $files; do
     # This assumes that exercises are only one directory deep
     # and that the primary module is named the same as the directory
     directory=$(dirname "${exercise}");
@@ -38,7 +44,10 @@ for exercise in exercises/*/tests; do
             sed -i '/\[ignore\]/d' $test
         done
 
-        if [ -n "$DENYWARNINGS" ]; then
+        # Run benchmarks instead of tests when enabled.
+        if [ -n "$BENCHMARK" ]; then
+            cargo bench
+        elif [ -n "$DENYWARNINGS" ]; then
             sed -i -e '1i #![deny(warnings)]' src/lib.rs
 
             # No-run mode so we see no test output.

--- a/exercises/parallel-letter-frequency/HINTS.md
+++ b/exercises/parallel-letter-frequency/HINTS.md
@@ -1,0 +1,32 @@
+# Parallel Letter Frequency in Rust
+
+Learn more about concurrency in Rust here:
+
+- [Concurrency](https://doc.rust-lang.org/book/concurrency.html)
+
+## Bonus
+
+This exercise also includes a benchmark, with a sequential implementation as a
+baseline. You can compare your solution to the benchmark. Observe the
+effect different size inputs have on the performance of each. Can you
+surpass the benchmark using concurrent programming techniques?
+
+As of this writing, test::Bencher is unstable and only available on
+*nightly* Rust. Run the benchmarks with Cargo:
+
+```
+cargo bench
+```
+
+If you are using rustup.rs:
+
+```
+rustup run nightly cargo bench
+```
+
+- [Benchmark tests](https://doc.rust-lang.org/book/benchmark-tests.html)
+
+Learn more about nightly Rust:
+
+- [Nightly Rust](https://doc.rust-lang.org/book/nightly-rust.html)
+- [Rustup: Working with nightly](https://github.com/rust-lang-nursery/rustup.rs#working-with-nightly-rust)

--- a/exercises/parallel-letter-frequency/benches/benchmark.rs
+++ b/exercises/parallel-letter-frequency/benches/benchmark.rs
@@ -1,0 +1,99 @@
+#![feature(test)]
+extern crate parallel_letter_frequency;
+extern crate test;
+
+use std::collections::HashMap;
+use test::Bencher;
+
+#[bench]
+fn bench_tiny_parallel(b: &mut Bencher) {
+    let tiny = &["a"];
+    b.iter(|| parallel_letter_frequency::frequency(tiny, 3));
+}
+
+#[bench]
+fn bench_tiny_sequential(b: &mut Bencher) {
+    let tiny = &["a"];
+    b.iter(|| frequency(tiny));
+}
+
+#[bench]
+fn bench_small_parallel(b: &mut Bencher) {
+    let texts = all_texts(1);
+    b.iter(|| parallel_letter_frequency::frequency(&texts, 3));
+}
+
+#[bench]
+fn bench_small_sequential(b: &mut Bencher) {
+    let texts = all_texts(1);
+    b.iter(|| frequency(&texts));
+}
+
+#[bench]
+fn bench_large_parallel(b: &mut Bencher) {
+    let texts = all_texts(30);
+    b.iter(|| parallel_letter_frequency::frequency(&texts, 3));
+}
+
+#[bench]
+fn bench_large_sequential(b: &mut Bencher) {
+    let texts = all_texts(30);
+    b.iter(|| frequency(&texts));
+}
+
+/// Simple sequential char frequency. Can it be beat?
+pub fn frequency(texts: &[&str]) -> HashMap<char, usize> {
+    let mut map = HashMap::new();
+
+    for line in texts {
+        for chr in line.chars().filter(|c| c.is_alphabetic()) {
+            if let Some(c) = chr.to_lowercase().next() {
+                (*map.entry(c).or_insert(0)) += 1;
+            }
+        }
+    }
+
+    map
+}
+
+fn all_texts(repeat: usize) -> Vec<&'static str> {
+    [ODE_AN_DIE_FREUDE, WILHELMUS, STAR_SPANGLED_BANNER]
+        .iter()
+        .cycle()
+        .take(3 * repeat)
+        .flat_map(|anthem| anthem.iter().cloned())
+        .collect()
+}
+
+// Poem by Friedrich Schiller. The corresponding music is the European Anthem.
+pub const ODE_AN_DIE_FREUDE: [&'static str; 8] = [
+    "Freude schöner Götterfunken",
+    "Tochter aus Elysium,",
+    "Wir betreten feuertrunken,",
+    "Himmlische, dein Heiligtum!",
+    "Deine Zauber binden wieder",
+    "Was die Mode streng geteilt;",
+    "Alle Menschen werden Brüder,",
+    "Wo dein sanfter Flügel weilt."];
+
+// Dutch national anthem
+pub const WILHELMUS: [&'static str; 8] = [
+    "Wilhelmus van Nassouwe",
+    "ben ik, van Duitsen bloed,",
+    "den vaderland getrouwe",
+    "blijf ik tot in den dood.",
+    "Een Prinse van Oranje",
+    "ben ik, vrij, onverveerd,",
+    "den Koning van Hispanje",
+    "heb ik altijd geëerd."];
+
+// American national anthem
+pub const STAR_SPANGLED_BANNER: [&'static str; 8] = [
+    "O say can you see by the dawn's early light,",
+    "What so proudly we hailed at the twilight's last gleaming,",
+    "Whose broad stripes and bright stars through the perilous fight,",
+    "O'er the ramparts we watched, were so gallantly streaming?",
+    "And the rockets' red glare, the bombs bursting in air,",
+    "Gave proof through the night that our flag was still there;",
+    "O say does that star-spangled banner yet wave,",
+    "O'er the land of the free and the home of the brave?"];


### PR DESCRIPTION
Addresses #244.

This runs benchmarks in a separate Travis-CI job. This way they run in parallel, only on nightly and benchmark failures aren't mixed with test failures.

`cargo bench` output:

```
running 2 tests
test bench_parallel   ... bench:     114,524 ns/iter (+/- 33,720)
test bench_sequential ... bench:      43,880 ns/iter (+/- 613)
test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured
```

You can see why I made this benchmark. 😄 

Visible in the job: https://travis-ci.org/exercism/xrust/jobs/191194852