### PR TITLE
README: Link to x-common, not x-api, CONTRIBUTING guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Exercism exercises in Rust
 
 ## Contributing Guide
 
-Please see the [contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data)
+Please see the [contributing guide](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
In https://github.com/exercism/x-common/pull/125, the x-common
CONTRIBUTING guide was created.

After that, the x-api contributing guide was gutted in
https://github.com/exercism/x-api/commit/a157350c6c9025314be8fbbaf82b90810bd9204e

This means that it doesn't really make sense to link to the x-api
contributing guide anymore - it has very little relevant information for
contributing to this track.

Consider that the template for a new track repository has been updated
so that they link to the x-common CONTRIBUTING guide too, not x-api:
https://github.com/exercism/x-template/commit/5f9143266d05b29317638f45f1cabaccb860e6ca