### PR TITLE
scrabble-score: add a test for the entire alphabet

### DIFF
--- a/exercises/scrabble-score/tests/scrabble-score.rs
+++ b/exercises/scrabble-score/tests/scrabble-score.rs
@@ -61,3 +61,8 @@ fn non_english_scrabble_letters_do_not_score() {
 fn empty_words_are_worth_zero() {
     assert_eq!(score(""), 0);
 }
+
+#[test]
+fn all_letters_work() {
+    assert_eq!(score("abcdefghijklmnopqrstuvwxyz"), 87);
+}

--- a/exercises/scrabble-score/tests/scrabble-score.rs
+++ b/exercises/scrabble-score/tests/scrabble-score.rs
@@ -63,6 +63,7 @@ fn empty_words_are_worth_zero() {
 }
 
 #[test]
+#[ignore]
 fn all_letters_work() {
     assert_eq!(score("abcdefghijklmnopqrstuvwxyz"), 87);
 }


### PR DESCRIPTION
After passing all tests for scrabble-score, I noticed I still didn't have all letters.
Adding them to my implementation at that point of course was trivial, but since there wasn't a test, I wrote one.
Here it is offered for inclusion at the source!

so comments, suggestions, nits and other (constructive) criticism welcome;
This is only my second[1] exercism contribution, so I may need some guidance ;-)

[1] [first contribution](https://github.com/exercism/xrust/pull/249)