### PR TITLE
luhn: Update example and add more tests

### DIFF
--- a/exercises/luhn/example.rs
+++ b/exercises/luhn/example.rs
@@ -1,5 +1,6 @@
 pub fn is_valid(candidate: &str) -> bool {
-    if candidate.chars().any(|c| c.is_alphabetic()) || candidate.chars().count() == 1 {
+    if candidate.chars().filter(|c| c.is_digit(10)).take(2).count() <= 1 ||
+       candidate.chars().any(|c| !c.is_digit(10) && c != ' ') {
         return false;
     }
 

--- a/exercises/luhn/tests/luhn.rs
+++ b/exercises/luhn/tests/luhn.rs
@@ -15,6 +15,12 @@ fn single_zero_string_is_invalid() {
 
 #[test]
 #[ignore]
+fn simple_valid_sin() {
+    assert!(is_valid(" 5 9 "));
+}
+
+#[test]
+#[ignore]
 fn valid_canadian_sin_is_valid() {
     assert!(is_valid("046 454 286"));
 }
@@ -35,4 +41,40 @@ fn invalid_credit_card_is_invalid() {
 #[ignore]
 fn strings_that_contain_non_digits_are_invalid() {
     assert!(!is_valid("046a 454 286"));
+}
+
+#[test]
+#[ignore]
+fn punctuation_is_invalid() {
+    assert!(!is_valid("055-444-285"));
+}
+
+#[test]
+#[ignore]
+fn symbols_are_invalid() {
+    assert!(!is_valid("055£ 444$ 285"));
+}
+
+#[test]
+#[ignore]
+fn single_digit_with_space_is_invalid() {
+    assert!(!is_valid(" 0"));
+}
+
+#[test]
+#[ignore]
+fn lots_of_zeros_are_valid() {
+    assert!(is_valid(" 00000"));
+}
+
+#[test]
+#[ignore]
+fn another_valid_sin() {
+    assert!(is_valid("055 444 285"));
+}
+
+#[test]
+#[ignore]
+fn nine_doubled_is_nine() {
+    assert!(is_valid("091"));
 }


### PR DESCRIPTION
The luhn test suite didn't cover a lot of cases, including:
 - Strings of zeros
 - Non-alphabetic characters
 - Numbers which are only valid if you reverse the string

This adds those tests and updates the example to properly reject symbols (and check that the sum isn't zero).

Let me know if I'm doing something wrong!


**_EDIT:_** FYI I was previously using `!c.is_whitespace()` rather than `c != ' '`. I switched because technically other whitespace like `\t` and `\n` isn't allowed by the letter of the rules.