### PR TITLE
hello-world: simplify to unconditional "Hello, World!"

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,6 @@
       "slug": "hello-world",
       "difficulty": 1,
       "topics": [
-        "Some/None",
         "println!"
       ]
     },

--- a/exercises/hello-world/example.rs
+++ b/exercises/hello-world/example.rs
@@ -1,6 +1,3 @@
-pub fn hello(name: Option<&str>) -> String {
-    match name {
-        Some(n) => format!("Hello, {}!", n),
-        None => "Hello, World!".to_string(),
-    }
+pub fn hello() -> &'static str {
+    "Hello, World!"
 }

--- a/exercises/hello-world/src/lib.rs
+++ b/exercises/hello-world/src/lib.rs
@@ -1,0 +1,5 @@
+// The &'static here means the return type has a static lifetime.
+// This is a Rust feature that you don't need to worry about now.
+pub fn hello() -> &'static str {
+    "Goodbye, World!"
+}

--- a/exercises/hello-world/tests/hello-world.rs
+++ b/exercises/hello-world/tests/hello-world.rs
@@ -1,18 +1,6 @@
 extern crate hello_world;
 
 #[test]
-fn test_no_name() {
-    assert_eq!("Hello, World!", hello_world::hello(None));
-}
-
-#[test]
-#[ignore]
-fn test_sample_name() {
-    assert_eq!("Hello, Alice!", hello_world::hello(Some("Alice")));
-}
-
-#[test]
-#[ignore]
-fn test_other_same_name() {
-    assert_eq!("Hello, Bob!", hello_world::hello(Some("Bob")));
+fn test_hello_world() {
+    assert_eq!("Hello, World!", hello_world::hello());
 }


### PR DESCRIPTION
The introductory exercise should require as little Rust knowledge as
necessary. We'd like to introduce `cargo test` here since it will be
used for all exercises, but introducing Option is too much.

https://github.com/exercism/x-common/issues/520

---

I wouldn't recommend merging this until the corresponding change is made in x-common.
Let's get it ready to go before then.