### PR TITLE
grade-school: Expect `Option<Vec<String>>` from grade; add stub file

### DIFF
--- a/exercises/grade-school/example.rs
+++ b/exercises/grade-school/example.rs
@@ -21,7 +21,7 @@ impl School {
         s
     }
 
-    pub fn grade(&self, grade: u32) -> Option<&Vec<String>> {
-        self.grades.get(&grade)
+    pub fn grade(&self, grade: u32) -> Option<Vec<String>> {
+        self.grades.get(&grade).map(|v| v.iter().cloned().collect())
     }
 }

--- a/exercises/grade-school/src/lib.rs
+++ b/exercises/grade-school/src/lib.rs
@@ -1,0 +1,26 @@
+#[allow(unused_variables)]
+
+pub struct School {
+}
+
+impl School {
+    pub fn new() -> School {
+        unimplemented!()
+    }
+
+    pub fn add(&mut self, grade: u32, student: &str) {
+        unimplemented!()
+    }
+
+    pub fn grades(&self) -> Vec<u32> {
+        unimplemented!()
+    }
+
+    // If grade returned an `Option<&Vec<String>>`,
+    // the internal implementation would be forced to keep a `Vec<String>` to lend out.
+    // By returning an owned vector instead,
+    // the internal implementation is free to use whatever it chooses.
+    pub fn grade(&self, grade: u32) -> Option<Vec<String>> {
+        unimplemented!()
+    }
+}

--- a/exercises/grade-school/tests/grade-school.rs
+++ b/exercises/grade-school/tests/grade-school.rs
@@ -1,7 +1,7 @@
 extern crate grade_school as school;
 
-fn stringvec_to_strvec(v: &Vec<String>) -> Vec<&str> {
-    v.iter().map(|s| s.as_ref()).collect()
+fn some_strings(v: Vec<&str>) -> Option<Vec<String>> {
+    Some(v.iter().map(|s| s.to_string()).collect())
 }
 
 #[test]
@@ -58,8 +58,8 @@ fn test_grade_when_no_students_have_that_grade() {
 fn test_grade_for_one_student() {
     let mut s = school::School::new();
     s.add(2, "Aimee");
-    assert_eq!(s.grade(2).map(|v| stringvec_to_strvec(v)),
-                Some(vec!["Aimee"]))
+    assert_eq!(s.grade(2),
+                some_strings(vec!["Aimee"]));
 }
 
 #[test]
@@ -69,8 +69,8 @@ fn test_grade_returns_students_sorted_by_name() {
     s.add(2, "James");
     s.add(2, "Blair");
     s.add(2, "Paul");
-    assert_eq!(s.grade(2).map(|v| stringvec_to_strvec(v)),
-               Some(vec!["Blair", "James", "Paul"]));
+    assert_eq!(s.grade(2),
+               some_strings(vec!["Blair", "James", "Paul"]));
 }
 
 #[test]
@@ -80,8 +80,8 @@ fn test_add_students_to_different_grades() {
     s.add(3, "Chelsea");
     s.add(7, "Logan");
     assert_eq!(s.grades(), vec!(3, 7));
-    assert_eq!(s.grade(3).map(|v| stringvec_to_strvec(v)),
-               Some(vec!["Chelsea"]));
-    assert_eq!(s.grade(7).map(|v| stringvec_to_strvec(v)),
-               Some(vec!["Logan"]));
+    assert_eq!(s.grade(3),
+               some_strings(vec!["Chelsea"]));
+    assert_eq!(s.grade(7),
+               some_strings(vec!["Logan"]));
 }


### PR DESCRIPTION
Previously, grade was expected to return an `Option<&Vec<String>>`.
Because there's a reference inside the lifetime, any implementing School
would have been required to maintain ownership of some vectors so that
they can be lended out. This unnecessarily restricts the implementation.
For example, some implementations may instead have preferred to use
BTreeSet.

If we expect grade to return `Option<Vec<String>>`, the fact that
ownership is given means that a new vector can be made from whatever
internal representation is used.

Closes #254.