### PR TITLE
added rotational-cipher exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -163,6 +163,17 @@
       ]
     },
     {
+      "slug": "rotational-cipher",
+      "difficulty": 4,
+      "topics": [
+        "str vs string",
+        "primitive types",
+        "iterators",
+        "chars",
+        "ascii"
+      ]
+    },
+    {
       "slug": "etl",
       "difficulty": 4,
       "topics": [

--- a/exercises/rotational-cipher/Cargo.lock
+++ b/exercises/rotational-cipher/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "rotational-cipher"
+version = "0.0.0"
+

--- a/exercises/rotational-cipher/Cargo.toml
+++ b/exercises/rotational-cipher/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "rotational-cipher"
+version = "0.0.0"
+authors = ["Chad Baxter <cbaxter@mail.umw.edu>"]

--- a/exercises/rotational-cipher/example.rs
+++ b/exercises/rotational-cipher/example.rs
@@ -1,0 +1,16 @@
+pub fn rotate(text: &str, shift_key: u8) -> String {
+
+    text.chars().map(|c| {
+        let case = if c.is_uppercase() {
+            'A'
+        } else {
+            'a'
+        } as u8;
+        if c.is_alphabetic() {
+            (((c as u8 - case + shift_key) % 26) + case) as char
+        } else {
+            c
+        }
+    }).collect::<String>()
+
+}

--- a/exercises/rotational-cipher/tests/rotational-cipher.rs
+++ b/exercises/rotational-cipher/tests/rotational-cipher.rs
@@ -1,0 +1,61 @@
+extern crate rotational_cipher as cipher;
+
+#[test]
+fn rotate_a_1() {
+    assert_eq!("b", cipher::rotate("a", 1));
+}
+
+#[test]
+#[ignore]
+fn rotate_a_26() {
+    assert_eq!("a", cipher::rotate("a", 26));
+}
+
+#[test]
+#[ignore]
+fn rotate_a_0() {
+    assert_eq!("a", cipher::rotate("a", 0));
+}
+
+#[test]
+#[ignore]
+fn rotate_m_13() {
+    assert_eq!("z", cipher::rotate("m", 13));
+}
+
+#[test]
+#[ignore]
+fn rotate_n_13_with_wrap() {
+    assert_eq!("a", cipher::rotate("n", 13));
+}
+
+#[test]
+#[ignore]
+fn rotate_caps() {
+    assert_eq!("TRL", cipher::rotate("OMG", 5));
+}
+
+#[test]
+#[ignore]
+fn rotate_spaces() {
+    assert_eq!("T R L", cipher::rotate("O M G", 5));
+}
+
+#[test]
+#[ignore]
+fn rotate_numbers() {
+    assert_eq!("Xiwxmrk 1 2 3 xiwxmrk", cipher::rotate("Testing 1 2 3 testing", 4));
+}
+
+#[test]
+#[ignore]
+fn rotate_punctuation() {
+    assert_eq!("Gzo\'n zvo, Bmviyhv!", cipher::rotate("Let\'s eat, Grandma!", 21));
+}
+
+#[test]
+#[ignore]
+fn rotate_all_the_letters() {
+    assert_eq!("Gur dhvpx oebja sbk whzcf bire gur ynml qbt.",
+        cipher::rotate("The quick brown fox jumps over the lazy dog.", 13));
+}


### PR DESCRIPTION
This cipher is the same as atbash except it is implemented in a way that allows for 27 possible keys. Some call this the Caesar cipher but the official cryptography term is rotational cipher. For more info see the readme in this pull request.

This exercise should come right after the atbash cipher in terms of ordering and difficulty.