### PR TITLE
replace nucleotide-codons with protein-translation

### DIFF
--- a/config.json
+++ b/config.json
@@ -381,7 +381,7 @@
       ]
     },
     {
-      "slug": "nucleotide-codons",
+      "slug": "protein-translation",
       "difficulty": 7,
       "topics": [
         "struct",
@@ -468,6 +468,7 @@
     }
   ],
   "deprecated": [
+    "nucleotide-codons",
     "hexadecimal"
   ],
   "ignored": [

--- a/exercises/nucleotide-codons/tests/codons.rs
+++ b/exercises/nucleotide-codons/tests/codons.rs
@@ -55,12 +55,30 @@ fn test_arginine_name() {
 
 #[test]
 #[ignore]
-fn test_invalid() {
+fn empty_is_invalid() {
     let info = codons::parse(make_pairs());
     assert!(info.name_for("").is_err());
-    assert!(info.name_for("VWX").is_err()); // X is not a shorthand
-    assert!(info.name_for("AB").is_err()); // too short
-    assert!(info.name_for("ABCD").is_err()); // too long
+}
+
+#[test]
+#[ignore]
+fn x_is_not_shorthand_so_is_invalid() {
+    let info = codons::parse(make_pairs());
+    assert!(info.name_for("VWX").is_err());
+}
+
+#[test]
+#[ignore]
+fn too_short_is_invalid() {
+    let info = codons::parse(make_pairs());
+    assert!(info.name_for("AT").is_err());
+}
+
+#[test]
+#[ignore]
+fn too_long_is_invalid() {
+    let info = codons::parse(make_pairs());
+    assert!(info.name_for("ATTA").is_err());
 }
 
 // The input data constructor. Returns a list of codon, name pairs.

--- a/exercises/nucleotide-codons/tests/codons.rs
+++ b/exercises/nucleotide-codons/tests/codons.rs
@@ -17,7 +17,8 @@ fn test_cysteine_tgt() {
 #[ignore]
 fn test_cysteine_tgy() { // "compressed" name for TGT and TGC
     let info = codons::parse(make_pairs());
-    assert_eq!(info.name_for("TGY"), Ok("cysteine"));
+    assert_eq!(info.name_for("TGT"), info.name_for("TGY"));
+    assert_eq!(info.name_for("TGC"), info.name_for("TGY"));
 }
 
 #[test]

--- a/exercises/protein-translation/Cargo.lock
+++ b/exercises/protein-translation/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "nucleotide_codons"
+version = "0.1.0"
+

--- a/exercises/protein-translation/Cargo.lock
+++ b/exercises/protein-translation/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
-name = "nucleotide_codons"
+name = "protein-translation"
 version = "0.1.0"
 

--- a/exercises/protein-translation/Cargo.toml
+++ b/exercises/protein-translation/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "nucleotide_codons"
+version = "0.1.0"
+authors = ["Peter Minten <peter@pminten.nl>"]

--- a/exercises/protein-translation/Cargo.toml
+++ b/exercises/protein-translation/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
-name = "nucleotide_codons"
+name = "protein-translation"
 version = "0.1.0"
 authors = ["Peter Minten <peter@pminten.nl>"]

--- a/exercises/protein-translation/example.rs
+++ b/exercises/protein-translation/example.rs
@@ -1,0 +1,40 @@
+use std::collections::HashMap;
+
+pub struct CodonInfo<'a> {
+    actual_codons: HashMap<&'a str, &'a str>
+}
+
+pub fn parse<'a>(pairs: Vec<(&'a str, &'a str)>) -> CodonInfo<'a> {
+    CodonInfo{
+        actual_codons: pairs.into_iter().collect()
+    }
+}
+
+impl<'a> CodonInfo<'a> {
+    pub fn name_for(&self, codon: &str) -> Result<&'a str, &'static str> {
+        if codon.len() != 3 {
+            return Err("invalid length")
+        }
+
+        let mut valid = true;
+        let lookup: String = codon.chars().map(|l| {
+            // Get an example of a "letter" represented by the possibly encoded letter.
+            // Since every codon represented by the compressed notation has to be of
+            // the desired amino acid just picking one at random will do.
+            match l {
+                'A' | 'W' | 'M' | 'R' | 'D' | 'H' | 'V' | 'N' => 'A',
+                'C' | 'S' | 'Y' | 'B' => 'C',
+                'G' | 'K' => 'G',
+                'T' => 'T',
+                _ => { valid = false; ' ' }
+            }
+        }).collect();
+        if !valid {
+            return Err("invalid char")
+        }
+
+        // If the input table is correct (which it is) every valid codon is in it
+        // so unwrap() shouldn't panic.
+        Ok(self.actual_codons.get(&lookup.as_ref()).unwrap())
+    }
+}

--- a/exercises/protein-translation/tests/codons.rs
+++ b/exercises/protein-translation/tests/codons.rs
@@ -1,0 +1,116 @@
+extern crate nucleotide_codons as codons;
+
+#[test]
+fn test_methionine() {
+    let info = codons::parse(make_pairs());
+    assert_eq!(info.name_for("ATG"), Ok("methionine"));
+}
+
+#[test]
+#[ignore]
+fn test_cysteine_tgt() {
+    let info = codons::parse(make_pairs());
+    assert_eq!(info.name_for("TGT"), Ok("cysteine"));
+}
+
+#[test]
+#[ignore]
+fn test_cysteine_tgy() { // "compressed" name for TGT and TGC
+    let info = codons::parse(make_pairs());
+    assert_eq!(info.name_for("TGT"), info.name_for("TGY"));
+    assert_eq!(info.name_for("TGC"), info.name_for("TGY"));
+}
+
+#[test]
+#[ignore]
+fn test_stop() {
+    let info = codons::parse(make_pairs());
+    assert_eq!(info.name_for("TAA"), Ok("stop codon"));
+}
+
+#[test]
+#[ignore]
+fn test_valine() {
+    let info = codons::parse(make_pairs());
+    assert_eq!(info.name_for("GTN"), Ok("valine"));
+}
+
+
+#[test]
+#[ignore]
+fn test_isoleucine() {
+    let info = codons::parse(make_pairs());
+    assert_eq!(info.name_for("ATH"), Ok("isoleucine"));
+}
+
+#[test]
+#[ignore]
+fn test_arginine_name() {
+    // In arginine CGA can be "compresed" both as CGN and as MGR
+    let info = codons::parse(make_pairs());
+    assert_eq!(info.name_for("CGA"), Ok("arginine"));
+    assert_eq!(info.name_for("CGN"), Ok("arginine"));
+    assert_eq!(info.name_for("MGR"), Ok("arginine"));
+}
+
+#[test]
+#[ignore]
+fn empty_is_invalid() {
+    let info = codons::parse(make_pairs());
+    assert!(info.name_for("").is_err());
+}
+
+#[test]
+#[ignore]
+fn x_is_not_shorthand_so_is_invalid() {
+    let info = codons::parse(make_pairs());
+    assert!(info.name_for("VWX").is_err());
+}
+
+#[test]
+#[ignore]
+fn too_short_is_invalid() {
+    let info = codons::parse(make_pairs());
+    assert!(info.name_for("AT").is_err());
+}
+
+#[test]
+#[ignore]
+fn too_long_is_invalid() {
+    let info = codons::parse(make_pairs());
+    assert!(info.name_for("ATTA").is_err());
+}
+
+// The input data constructor. Returns a list of codon, name pairs.
+fn make_pairs() -> Vec<(&'static str, &'static str)> {
+    let grouped = vec![
+        ("isoleucine", vec!["ATT", "ATC", "ATA"]),
+        ("leucine", vec!["CTT", "CTC", "CTA", "CTG", "TTA", "TTG"]),
+        ("valine", vec!["GTT", "GTC", "GTA", "GTG"]),
+        ("phenylalanine", vec!["TTT", "TTC"]),
+        ("methionine", vec!["ATG"]),
+        ("cysteine", vec!["TGT", "TGC"]),
+        ("alanine", vec!["GCT", "GCC", "GCA", "GCG"]),
+        ("glycine", vec!["GGT", "GGC", "GGA", "GGG"]),
+        ("proline", vec!["CCT", "CCC", "CCA", "CCG"]),
+        ("threonine", vec!["ACT", "ACC", "ACA", "ACG"]),
+        ("serine", vec!["TCT", "TCC", "TCA", "TCG", "AGT", "AGC"]),
+        ("tyrosine", vec!["TAT", "TAC"]),
+        ("tryptophan", vec!["TGG"]),
+        ("glutamine", vec!["CAA", "CAG"]),
+        ("asparagine", vec!["AAT", "AAC"]),
+        ("histidine", vec!["CAT", "CAC"]),
+        ("glutamic acid", vec!["GAA", "GAG"]),
+        ("aspartic acid", vec!["GAT", "GAC"]),
+        ("lysine", vec!["AAA", "AAG"]),
+        ("arginine", vec!["CGT", "CGC", "CGA", "CGG", "AGA", "AGG"]),
+        ("stop codon", vec!["TAA", "TAG", "TGA"])];
+    let mut pairs = Vec::<(&'static str, &'static str)>::new();
+    for (name, codons) in grouped.into_iter() {
+        for codon in codons {
+            pairs.push((codon, name));
+        }
+    };
+    pairs.sort_by(|&(_, a), &(_, b)| a.cmp(b));
+    return pairs
+}

--- a/exercises/protein-translation/tests/proteins.rs
+++ b/exercises/protein-translation/tests/proteins.rs
@@ -1,22 +1,22 @@
-extern crate nucleotide_codons as codons;
+extern crate protein_translation as proteins;
 
 #[test]
 fn test_methionine() {
-    let info = codons::parse(make_pairs());
+    let info = proteins::parse(make_pairs());
     assert_eq!(info.name_for("ATG"), Ok("methionine"));
 }
 
 #[test]
 #[ignore]
 fn test_cysteine_tgt() {
-    let info = codons::parse(make_pairs());
+    let info = proteins::parse(make_pairs());
     assert_eq!(info.name_for("TGT"), Ok("cysteine"));
 }
 
 #[test]
 #[ignore]
 fn test_cysteine_tgy() { // "compressed" name for TGT and TGC
-    let info = codons::parse(make_pairs());
+    let info = proteins::parse(make_pairs());
     assert_eq!(info.name_for("TGT"), info.name_for("TGY"));
     assert_eq!(info.name_for("TGC"), info.name_for("TGY"));
 }
@@ -24,14 +24,14 @@ fn test_cysteine_tgy() { // "compressed" name for TGT and TGC
 #[test]
 #[ignore]
 fn test_stop() {
-    let info = codons::parse(make_pairs());
+    let info = proteins::parse(make_pairs());
     assert_eq!(info.name_for("TAA"), Ok("stop codon"));
 }
 
 #[test]
 #[ignore]
 fn test_valine() {
-    let info = codons::parse(make_pairs());
+    let info = proteins::parse(make_pairs());
     assert_eq!(info.name_for("GTN"), Ok("valine"));
 }
 
@@ -39,7 +39,7 @@ fn test_valine() {
 #[test]
 #[ignore]
 fn test_isoleucine() {
-    let info = codons::parse(make_pairs());
+    let info = proteins::parse(make_pairs());
     assert_eq!(info.name_for("ATH"), Ok("isoleucine"));
 }
 
@@ -47,7 +47,7 @@ fn test_isoleucine() {
 #[ignore]
 fn test_arginine_name() {
     // In arginine CGA can be "compresed" both as CGN and as MGR
-    let info = codons::parse(make_pairs());
+    let info = proteins::parse(make_pairs());
     assert_eq!(info.name_for("CGA"), Ok("arginine"));
     assert_eq!(info.name_for("CGN"), Ok("arginine"));
     assert_eq!(info.name_for("MGR"), Ok("arginine"));
@@ -56,28 +56,28 @@ fn test_arginine_name() {
 #[test]
 #[ignore]
 fn empty_is_invalid() {
-    let info = codons::parse(make_pairs());
+    let info = proteins::parse(make_pairs());
     assert!(info.name_for("").is_err());
 }
 
 #[test]
 #[ignore]
 fn x_is_not_shorthand_so_is_invalid() {
-    let info = codons::parse(make_pairs());
+    let info = proteins::parse(make_pairs());
     assert!(info.name_for("VWX").is_err());
 }
 
 #[test]
 #[ignore]
 fn too_short_is_invalid() {
-    let info = codons::parse(make_pairs());
+    let info = proteins::parse(make_pairs());
     assert!(info.name_for("AT").is_err());
 }
 
 #[test]
 #[ignore]
 fn too_long_is_invalid() {
-    let info = codons::parse(make_pairs());
+    let info = proteins::parse(make_pairs());
     assert!(info.name_for("ATTA").is_err());
 }
 


### PR DESCRIPTION
As noted in https://github.com/exercism/x-common/issues/268 these two
exercises are the same. In this transitionary period, we deprecate
nucleotide-codons (but keep its files available).

If we wish to replace nucleotide-codons with protein-translation
completely, then a database surgery will be needed to transfer all
submissions from nucleotide-codons to protein-translation.