### PR TITLE
Fix queen-attack's #[should_panic] parameter

### DIFF
--- a/exercises/queen-attack/tests/queen-attack.rs
+++ b/exercises/queen-attack/tests/queen-attack.rs
@@ -24,7 +24,7 @@ fn queen_is_created_with_a_ok_position() {
 
 #[test]
 #[ignore]
-#[should_panic(expected = "Invalid Position")]
+#[should_panic]
 fn queen_panics_with_err_position() {
     Queen::new(ChessPosition::new(-1, 4).unwrap());
 }


### PR DESCRIPTION
The .unwrap() method does not generate a panic string, so the test
always failed.  The test can be fixed either by keeping the .unwrap()
call and removing the `expected` argument from the attribute, or by
keeping the attribute as-is, and using the .expect() method.

I've picked the former option to remain consistent with other tests (in
this problem and others) that use .unwrap().