### PR TITLE
README: Add Travis image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # xRust
 
+[![Build Status](https://travis-ci.org/exercism/xrust.svg?branch=master)](https://travis-ci.org/exercism/xrust)
 [![Join the chat at https://gitter.im/exercism/xrust](https://badges.gitter.im/exercism/xrust.svg)](https://gitter.im/exercism/xrust?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Exercism exercises in Rust


### PR DESCRIPTION
It seems good to have the build status easily visible and should make it
easier to get to the build status (instead of have to look for it at
travis-ci.org)