### PR TITLE
triangle: Allow equilateral triangles to also be isosceles

### DIFF
--- a/exercises/triangle/tests/triangle.rs
+++ b/exercises/triangle/tests/triangle.rs
@@ -23,7 +23,6 @@ fn equilateral_triangles_have_equal_sides() {
     let sides = [2, 2, 2];
     let triangle = Triangle::build(sides).unwrap();
     assert!(triangle.is_equilateral());
-    assert!(!triangle.is_isosceles());
     assert!(!triangle.is_scalene());
 }
 
@@ -33,7 +32,6 @@ fn larger_equilateral_triangles_have_equal_sides() {
     let sides = [10, 10, 10];
     let triangle = Triangle::build(sides).unwrap();
     assert!(triangle.is_equilateral());
-    assert!(!triangle.is_isosceles());
     assert!(!triangle.is_scalene());
 }
 
@@ -156,7 +154,6 @@ fn sum_of_two_sides_must_equal_or_exceed_the_remaining_side_two() {
 //     let sides = [0.2, 0.2, 0.2];
 //     let triangle = Triangle::build(sides).unwrap();
 //     assert!(triangle.is_equilateral());
-//     assert!(!triangle.is_isosceles());
 //     assert!(!triangle.is_scalene());
 // }
 //


### PR DESCRIPTION
[The triangle problem description](https://github.com/exercism/x-common/blob/d7a3c09b6758a8a5d59a2e140e6684031316280a/exercises/triangle/description.md) says the following:

> An isosceles triangle has at least two sides the same length. (It is sometimes specified as having exactly two sides the same length, but for the purposes of this exercise we'll say at least two.)

However, previously the tests for this exercise only allowed isosceles triangles with exactly two sides of the same length.

Removing the expectation that equilateral triangles must return false for `.is_isosceles()` allows students the freedom to decide which definition of "isosceles" they want to implement.