### PR TITLE
triangle: Fix spelling of "isosceles" in tests

### DIFF
--- a/exercises/triangle/tests/triangle.rs
+++ b/exercises/triangle/tests/triangle.rs
@@ -37,7 +37,7 @@ fn larger_equilateral_triangles_have_equal_sides() {
 
 #[test]
 #[ignore]
-fn isocseles_triangles_have_two_equal_sides_one() {
+fn isosceles_triangles_have_two_equal_sides_one() {
     let sides = [3, 4, 4];
     let triangle = Triangle::build(sides).unwrap();
     assert!(!triangle.is_equilateral());
@@ -47,7 +47,7 @@ fn isocseles_triangles_have_two_equal_sides_one() {
 
 #[test]
 #[ignore]
-fn isocseles_triangles_have_two_equal_sides_two() {
+fn isosceles_triangles_have_two_equal_sides_two() {
     let sides = [4, 4, 3];
     let triangle = Triangle::build(sides).unwrap();
     assert!(!triangle.is_equilateral());
@@ -57,7 +57,7 @@ fn isocseles_triangles_have_two_equal_sides_two() {
 
 #[test]
 #[ignore]
-fn isocseles_triangles_have_two_equal_sides_three() {
+fn isosceles_triangles_have_two_equal_sides_three() {
     let sides = [4, 3, 4];
     let triangle = Triangle::build(sides).unwrap();
     assert!(!triangle.is_equilateral());
@@ -67,7 +67,7 @@ fn isocseles_triangles_have_two_equal_sides_three() {
 
 #[test]
 #[ignore]
-fn isocseles_triangles_have_two_equal_sides_four() {
+fn isosceles_triangles_have_two_equal_sides_four() {
     let sides = [4, 7, 4];
     let triangle = Triangle::build(sides).unwrap();
     assert!(!triangle.is_equilateral());
@@ -158,7 +158,7 @@ fn sum_of_two_sides_must_equal_or_exceed_the_remaining_side_two() {
 // }
 //
 // #[test]
-// fn isocseles_triangle_with_floating_point_sides() {
+// fn isosceles_triangle_with_floating_point_sides() {
 //     let sides = [0.3, 0.4, 0.4];
 //     let triangle = Triangle::build(sides).unwrap();
 //     assert!(!triangle.is_equilateral());


### PR DESCRIPTION
This word is hard to spell! See exercism/x-common#749 for another misspelling.