### PR TITLE
declare compliance with x-common, where applicable

### DIFF
--- a/exercises/acronym/Cargo.lock
+++ b/exercises/acronym/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "acronym"
-version = "0.1.0"
+version = "1.0.0"
 

--- a/exercises/acronym/Cargo.toml
+++ b/exercises/acronym/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "acronym"
-version = "0.1.0"
+version = "1.0.0"
 
 [dependencies]

--- a/exercises/all-your-base/Cargo.lock
+++ b/exercises/all-your-base/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "allyourbase"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/all-your-base/Cargo.toml
+++ b/exercises/all-your-base/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "allyourbase"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/allergies/Cargo.lock
+++ b/exercises/allergies/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "allergies"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/allergies/Cargo.toml
+++ b/exercises/allergies/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "allergies"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/alphametics/Cargo.lock
+++ b/exercises/alphametics/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "alphametics"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/alphametics/Cargo.toml
+++ b/exercises/alphametics/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "alphametics"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/atbash-cipher/Cargo.lock
+++ b/exercises/atbash-cipher/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "atbash-cipher"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/atbash-cipher/Cargo.toml
+++ b/exercises/atbash-cipher/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "atbash-cipher"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/bowling/Cargo.toml
+++ b/exercises/bowling/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "bowling"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/bracket-push/Cargo.lock
+++ b/exercises/bracket-push/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "bracket-push"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/bracket-push/Cargo.toml
+++ b/exercises/bracket-push/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "bracket-push"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/custom-set/Cargo.lock
+++ b/exercises/custom-set/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "custom-set"
-version = "0.0.0"
+version = "1.0.1"
 

--- a/exercises/custom-set/Cargo.toml
+++ b/exercises/custom-set/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "custom-set"
-version = "0.0.0"
+version = "1.0.1"

--- a/exercises/dominoes/Cargo.lock
+++ b/exercises/dominoes/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "dominoes"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/dominoes/Cargo.toml
+++ b/exercises/dominoes/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "dominoes"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/gigasecond/Cargo.lock
+++ b/exercises/gigasecond/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "gigasecond"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "chrono 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/exercises/gigasecond/Cargo.toml
+++ b/exercises/gigasecond/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gigasecond"
-version = "0.0.0"
+version = "1.0.0"
 
 [dependencies]
 chrono = "0.2"

--- a/exercises/grains/Cargo.toml
+++ b/exercises/grains/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "grains"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/hello-world/Cargo.lock
+++ b/exercises/hello-world/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "hello-world"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/hello-world/Cargo.toml
+++ b/exercises/hello-world/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "hello-world"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/largest-series-product/Cargo.toml
+++ b/exercises/largest-series-product/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "largest-series-product"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/leap/Cargo.lock
+++ b/exercises/leap/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "leap"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/leap/Cargo.toml
+++ b/exercises/leap/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "leap"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/pascals-triangle/Cargo.toml
+++ b/exercises/pascals-triangle/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "pascals-triangle"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/queen-attack/Cargo.lock
+++ b/exercises/queen-attack/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "queen-attack"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/queen-attack/Cargo.toml
+++ b/exercises/queen-attack/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "queen-attack"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/react/Cargo.lock
+++ b/exercises/react/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "react"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/react/Cargo.toml
+++ b/exercises/react/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "react"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/robot-simulator/Cargo.lock
+++ b/exercises/robot-simulator/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "robot-simulator"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/robot-simulator/Cargo.toml
+++ b/exercises/robot-simulator/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "robot-simulator"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/roman-numerals/Cargo.lock
+++ b/exercises/roman-numerals/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "roman-numerals"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/roman-numerals/Cargo.toml
+++ b/exercises/roman-numerals/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "roman-numerals"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/rotational-cipher/Cargo.lock
+++ b/exercises/rotational-cipher/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "rotational-cipher"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/rotational-cipher/Cargo.toml
+++ b/exercises/rotational-cipher/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "rotational-cipher"
-version = "0.0.0"
+version = "1.0.0"
 authors = ["Chad Baxter <cbaxter@mail.umw.edu>"]

--- a/exercises/run-length-encoding/Cargo.lock
+++ b/exercises/run-length-encoding/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "run-length-encoding"
-version = "0.1.0"
+version = "1.0.0"
 

--- a/exercises/run-length-encoding/Cargo.toml
+++ b/exercises/run-length-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "run-length-encoding"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["zombiefungus <divmermarlav@gmail.com>"]
 
 [dependencies]

--- a/exercises/scrabble-score/Cargo.lock
+++ b/exercises/scrabble-score/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "scrabble-score"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/scrabble-score/Cargo.toml
+++ b/exercises/scrabble-score/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "scrabble-score"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/sieve/Cargo.lock
+++ b/exercises/sieve/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "sieve"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/sieve/Cargo.toml
+++ b/exercises/sieve/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "sieve"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/space-age/Cargo.lock
+++ b/exercises/space-age/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "space-age"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/space-age/Cargo.toml
+++ b/exercises/space-age/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "space-age"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/sum-of-multiples/Cargo.toml
+++ b/exercises/sum-of-multiples/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "sum-of-multiples"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/variable-length-quantity/Cargo.lock
+++ b/exercises/variable-length-quantity/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "variable-length-quantity"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/variable-length-quantity/Cargo.toml
+++ b/exercises/variable-length-quantity/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "variable-length-quantity"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/wordy/Cargo.lock
+++ b/exercises/wordy/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "wordy"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/wordy/Cargo.toml
+++ b/exercises/wordy/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "wordy"
-version = "0.0.0"
+version = "1.0.0"


### PR DESCRIPTION
closes #281 

Where our exercise already matches the x-common tests, this is now noted in the Cargo.* files.

Where there were small differences but I still deemed the exercise to be up to date, I noted this in a commit comment, so take note of those differences.

**Out of scope for this PR: Actually changing any test suites**. This PR is only for figuring out where we are already compliant. Changing test suites will come in other PRs for the respective exercises.

List of exercises that were declared up-to-date as a result (26):

              pascals-triangle: 1.0.0 == 1.0.0
                 all-your-base: 1.0.0 == 1.0.0
                         wordy: 1.0.0 == 1.0.0
                    gigasecond: 1.0.0 == 1.0.0
                scrabble-score: 1.0.0 == 1.0.0
                      dominoes: 1.0.0 == 1.0.0
           run-length-encoding: 1.0.0 == 1.0.0
                    custom-set: 1.0.1 == 1.0.1
                     space-age: 1.0.0 == 1.0.0
               robot-simulator: 1.0.0 == 1.0.0
                  queen-attack: 1.0.0 == 1.0.0
                       acronym: 1.0.0 == 1.0.0
                     allergies: 1.0.0 == 1.0.0
              sum-of-multiples: 1.0.0 == 1.0.0
                 atbash-cipher: 1.0.0 == 1.0.0
        largest-series-product: 1.0.0 == 1.0.0
                        grains: 1.0.0 == 1.0.0
                         sieve: 1.0.0 == 1.0.0
             rotational-cipher: 1.0.0 == 1.0.0
                         react: 1.0.0 == 1.0.0
                roman-numerals: 1.0.0 == 1.0.0
                          leap: 1.0.0 == 1.0.0
                   hello-world: 1.0.0 == 1.0.0
      variable-length-quantity: 1.0.0 == 1.0.0
                       bowling: 1.0.0 == 1.0.0
                   alphametics: 1.0.0 == 1.0.0

List of exercises that are up-to-date with a certain x-common version, but there is nevertheless a new x-common version (1):

                  bracket-push: 1.0.0 -> 1.1.0

List of exercises that were not deemed to be up-to-date to the current (or any previously-versioned) version, therefore were not touched (21):

                    rectangles: 0.0.0 -> 1.0.0
                       hamming: 0.0.0 -> 1.0.0
                   minesweeper: 0.0.0 -> 1.0.0
                     beer-song: 0.0.0 -> 1.0.0
                         forth: 0.0.0 -> 1.0.0
                       pangram: 0.0.0 -> 1.0.0
                  phone-number: 0.0.0 -> 1.2.0
                     raindrops: 0.0.0 -> 1.0.0
               circular-buffer: 0.0.0 -> 1.0.0
                      triangle: 0.0.0 -> 1.0.0
                          luhn: 0.0.0 -> 1.0.0
                       anagram: 0.0.0 -> 1.0.1
                   ocr-numbers: 0.0.0 -> 1.0.0
                    tournament: 0.0.0 -> 1.3.0
                    word-count: 0.0.0 -> 1.0.0
              nucleotide-count: 0.0.0 -> 1.0.0
         difference-of-squares: 0.0.0 -> 1.0.0
             rna-transcription: 0.0.0 -> 1.0.0
                           bob: 0.0.0 -> 1.0.0
                           etl: 0.0.0 -> 1.0.0
                       sublist: 0.0.0 -> 1.0.0


List of exercises that don't have a JSON file, so also were not touched (6).


                    luhn-trait: 0.0.0 -> still no JSON file
                     luhn-from: 0.0.0 -> still no JSON file
     parallel-letter-frequency: 0.0.0 -> still no JSON file
                  grade-school: 0.0.0 -> still no JSON file
           protein-translation: 0.1.0 -> still no JSON file
                    robot-name: 0.0.0 -> still no JSON file
