### PR TITLE
dominoes 1.0.1: correctly declare nine elements in largest case

### DIFF
--- a/exercises/dominoes/Cargo.lock
+++ b/exercises/dominoes/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "dominoes"
-version = "1.0.0"
+version = "1.0.1"
 

--- a/exercises/dominoes/Cargo.toml
+++ b/exercises/dominoes/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "dominoes"
-version = "1.0.0"
+version = "1.0.1"

--- a/exercises/dominoes/tests/dominoes.rs
+++ b/exercises/dominoes/tests/dominoes.rs
@@ -152,7 +152,7 @@ fn separate_loops() {
 
 #[test]
 #[ignore]
-fn ten_elements() {
+fn nine_elements() {
     let input = vec!((1, 2), (5, 3), (3, 1), (1, 2), (2, 4), (1, 6), (2, 3), (3, 4), (5, 6));
     assert_correct(&input);
 }


### PR DESCRIPTION
There have always been nine elements, ever since the origin of this test
in https://github.com/exercism/xrust/pull/13#discussion_r115148635

The description incorrectly claimed ten.

https://github.com/exercism/x-common/pull/777