### PR TITLE
config: Ignore description.md and metadata.yml

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "slug": "rust",
   "language": "Rust",
+  "ignore_pattern": "example|description.md|metadata.yml",
   "repository": "https://github.com/exercism/xrust",
   "active": true,
   "exercises": [


### PR DESCRIPTION
They were created for #248, but since they're not in the ignore_pattern
they are being served.

See for proof:
http://x.exercism.io/v2/exercises/rust/luhn-from
http://x.exercism.io/v2/exercises/rust/luhn-trait

And note how description.md and metadata.yml appear inside the response.