### PR TITLE
copy description.md and metadata.yml to .meta directory

### DIFF
--- a/exercises/luhn-from/.meta/description.md
+++ b/exercises/luhn-from/.meta/description.md
@@ -1,0 +1,9 @@
+# Luhn: Using the From Trait
+
+Before doing this exercise you should probably do the original Luhn exercise. If you have not completed Luhn, you can get it by running the command:
+
+> `exercism fetch rust luhn`
+
+In the original Luhn exercise you only validated strings, but the Luhn algorithm can be applied to integers as well.
+
+In this exercise you'll implement the [From trait](https://doc.rust-lang.org/std/convert/trait.From.html) to convert strings, strs and unsigned integers into a Struct that performs the validation.

--- a/exercises/luhn-from/.meta/metadata.yml
+++ b/exercises/luhn-from/.meta/metadata.yml
@@ -1,0 +1,3 @@
+---
+blurb: "Luhn: Using the From Trait"
+source: "The Rust track maintainers, based on the original Luhn exercise"

--- a/exercises/luhn-trait/.meta/description.md
+++ b/exercises/luhn-trait/.meta/description.md
@@ -1,0 +1,17 @@
+# Luhn: Using a Custom Trait
+
+Before doing this exercise you should probably do the original Luhn exercise and its successor, "Luhn: Using the From Trait"
+
+To get the original Luhn exercise, run `exercism fetch rust luhn`
+
+To get the "Luhn: Using the From Trait" exercise, run `exercism fetch rust luhn-from`
+
+In the original Luhn exercise you only validated strings, but the Luhn algorithm can be applied to integers as well.
+
+In "Luhn: Using the From Trait" you implemented a From trait, which also required you to create a Luhn struct.
+
+Instead of creating a Struct just to perform the validation, what if you you validated the primitives (i.e, String, u8, etc.) themselves?
+
+In this exercise you'll create and implement a custom [trait](https://doc.rust-lang.org/book/traits.html) that performs the validation.
+
+Note: It is [not idiomatic Rust to implement traits on on primitives](https://doc.rust-lang.org/book/traits.html#rules-for-implementing-traits). In this exercise we're showing something that you _can_ do, not something you _should_ do. If you find yourself implementing traits on primitives, perhaps you have a case of [Primitive Obsession](http://wiki.c2.com/?PrimitiveObsession).

--- a/exercises/luhn-trait/.meta/metadata.yml
+++ b/exercises/luhn-trait/.meta/metadata.yml
@@ -1,0 +1,3 @@
+---
+blurb: "Luhn: Using a Custom Trait"
+source: "The Rust track maintainters, based on the original Luhn exercise"


### PR DESCRIPTION
If, as proposed in https://github.com/exercism/trackler/issues/45, the
proper location of these files moves to the .meta directory, this allows
Trackler to freely change its expectations without having to wait for
this track to move and/or support multiple locations at once.

If the proposal is accepted and implemented, the original files may be
removed. Of course, until then, the original files must remain, since
Trackler still expects them at the original location.