### PR TITLE
difference-of-squares 1.1.0: Add tests for 1

### DIFF
--- a/exercises/difference-of-squares/Cargo.lock
+++ b/exercises/difference-of-squares/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "difference-of-squares"
-version = "0.0.0"
+version = "1.1.0"
 

--- a/exercises/difference-of-squares/Cargo.toml
+++ b/exercises/difference-of-squares/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "difference-of-squares"
-version = "0.0.0"
+version = "1.1.0"

--- a/exercises/difference-of-squares/tests/difference-of-square.rs
+++ b/exercises/difference-of-squares/tests/difference-of-square.rs
@@ -7,26 +7,26 @@ fn test_square_of_sum_5() {
 
 #[test]
 #[ignore]
-fn test_sum_of_squares_5() {
-    assert_eq!(55, squares::sum_of_squares(5));
-}
-
-#[test]
-#[ignore]
-fn test_difference_5() {
-    assert_eq!(170, squares::difference(5));
-}
-
-#[test]
-#[ignore]
 fn test_square_of_sum_100() {
     assert_eq!(25502500, squares::square_of_sum(100));
 }
 
 #[test]
 #[ignore]
+fn test_sum_of_squares_5() {
+    assert_eq!(55, squares::sum_of_squares(5));
+}
+
+#[test]
+#[ignore]
 fn test_sum_of_squares_100() {
     assert_eq!(338350, squares::sum_of_squares(100));
+}
+
+#[test]
+#[ignore]
+fn test_difference_5() {
+    assert_eq!(170, squares::difference(5));
 }
 
 #[test]

--- a/exercises/difference-of-squares/tests/difference-of-square.rs
+++ b/exercises/difference-of-squares/tests/difference-of-square.rs
@@ -1,6 +1,12 @@
 extern crate difference_of_squares as squares;
 
 #[test]
+fn test_square_of_sum_1() {
+    assert_eq!(1, squares::square_of_sum(1));
+}
+
+#[test]
+#[ignore]
 fn test_square_of_sum_5() {
     assert_eq!(225, squares::square_of_sum(5));
 }
@@ -13,6 +19,12 @@ fn test_square_of_sum_100() {
 
 #[test]
 #[ignore]
+fn test_sum_of_squares_1() {
+    assert_eq!(1, squares::sum_of_squares(1));
+}
+
+#[test]
+#[ignore]
 fn test_sum_of_squares_5() {
     assert_eq!(55, squares::sum_of_squares(5));
 }
@@ -21,6 +33,12 @@ fn test_sum_of_squares_5() {
 #[ignore]
 fn test_sum_of_squares_100() {
     assert_eq!(338350, squares::sum_of_squares(100));
+}
+
+#[test]
+#[ignore]
+fn test_difference_1() {
+    assert_eq!(0, squares::difference(1));
 }
 
 #[test]


### PR DESCRIPTION
exercism/x-common#791

---

Supporting commit: Test one function at a time

Instead of testing all three functions for 5 and then all three
functions for 100, let's test one function at a time, so that the
student can make sure one function is solid before moving onto the next.

This also better matches the order the tests are listed in in x-common
(though we are free to change the order if we really want).

Honestly, I don't feel strongly about this, so this is just arbitrary.