### PR TITLE
minesweeper 1.0.0: Use x-common cases

### DIFF
--- a/exercises/minesweeper/Cargo.lock
+++ b/exercises/minesweeper/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "minesweeper"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/minesweeper/Cargo.toml
+++ b/exercises/minesweeper/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "minesweeper"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/minesweeper/example.rs
+++ b/exercises/minesweeper/example.rs
@@ -36,6 +36,9 @@ impl Board {
 }
 
 pub fn annotate(pieces: &[&str]) -> Vec<String> {
+    if pieces.len() == 0 {
+        return Vec::new();
+    }
     let pieces_vec = pieces.iter().map(|&r| r.chars().collect()).collect();
     Board {pieces: pieces_vec, num_rows: pieces.len(), num_cols: pieces[0].len()}.annotated()
 }

--- a/exercises/minesweeper/tests/minesweeper.rs
+++ b/exercises/minesweeper/tests/minesweeper.rs
@@ -21,98 +21,93 @@ fn run_test(test_case: &[&str]) {
 }
 
 #[test]
-fn empty_board_has_no_annotations() {
+fn no_rows() {
+    run_test(&[
+    ]);
+}
+
+#[test]
+#[ignore]
+fn no_columns() {
+    run_test(&[
+        "",
+    ]);
+}
+
+#[test]
+#[ignore]
+fn no_mines() {
     run_test(&[
         "   ",
         "   ",
-        "   "
+        "   ",
     ]);
 }
 
 #[test]
 #[ignore]
-fn board_full_of_mines_has_no_annotations() {
+fn board_with_only_mines() {
     run_test(&[
         "***",
         "***",
-        "***"
+        "***",
     ]);
 }
 
 #[test]
 #[ignore]
-fn one_horizontal_row_with_one_mine() {
+fn mine_surrounded_by_spaces() {
     run_test(&[
-        "   1*1 "
+        "111",
+        "1*1",
+        "111",
     ]);
 }
 
 #[test]
 #[ignore]
-fn one_horizontal_row_with_two_mines() {
+fn space_surrounded_by_mines() {
     run_test(&[
-        " 1*2*1 "
+        "***",
+        "*8*",
+        "***",
     ]);
 }
 
 #[test]
 #[ignore]
-fn one_horizontal_row_with_one_mine_at_the_left_end() {
+fn horizontal_line() {
     run_test(&[
-        "*1  "
+        "1*2*1",
     ]);
 }
 
 #[test]
 #[ignore]
-fn one_horizontal_row_with_one_mine_at_the_right_end() {
+fn horizontal_line_mines_at_edges() {
     run_test(&[
-        "  1*"
+        "*1 1*",
     ]);
 }
 
 #[test]
 #[ignore]
-fn one_vertical_row_with_one_mine() {
+fn vertical_line() {
     run_test(&[
-        " ",
-        "1",
-        "*",
-        "1",
-        " ",
-    ]);
-}
-
-#[test]
-#[ignore]
-fn one_vertical_row_with_two_mines() {
-    run_test(&[
-        " ",
         "1",
         "*",
         "2",
         "*",
         "1",
-        " ",
     ]);
 }
 
 #[test]
 #[ignore]
-fn one_vertical_row_with_one_mine_at_the_top() {
+fn vertical_line_mines_at_edges() {
     run_test(&[
         "*",
         "1",
-        " ",
-        " ",
-    ]);
-}
-
-#[test]
-#[ignore]
-fn one_vertical_row_with_one_mine_at_the_bottom() {
-    run_test(&[
-        " ",
         " ",
         "1",
         "*",
@@ -121,22 +116,25 @@ fn one_vertical_row_with_one_mine_at_the_bottom() {
 
 #[test]
 #[ignore]
-fn one_mine_in_the_middle() {
-    run_test(&[
-        "***",
-        "*8*",
-        "***"
-    ]);
-}
-
-#[test]
-#[ignore]
-fn complex_case() {
+fn cross() {
     run_test(&[
         " 2*2 ",
         "25*52",
         "*****",
         "25*52",
         " 2*2 ",
+    ]);
+}
+
+#[test]
+#[ignore]
+fn large_board() {
+    run_test(&[
+        "1*22*1",
+        "12*322",
+        " 123*2",
+        "112*4*",
+        "1*22*2",
+        "111111",
     ]);
 }


### PR DESCRIPTION
https://github.com/exercism/x-common/pull/330

As noted, ultimately the list of cases encompasses all the same tests as
before, with a few additions:

* No rows
* No columns
* Mine surrounded by spaces
* 6x6 asymmetric board with 8 mines
* The mines-at-edges cases have been combined (one for horizontal, one
  for vertical)

No attempt was made to make the diff as small as possible. Instead, the
file was simply overwritten with a small generator script (#280)

```ruby
require 'json'

data = JSON.parse(File.read(File.join(__dir__, 'canonical-data.json')))

puts <<PREAMBLE
extern crate minesweeper;

use minesweeper::annotate;

fn remove_annotations(board: &[&str]) -> Vec<String> {
    board.iter().map(|r| remove_annotations_in_row(r)).collect()
}

fn remove_annotations_in_row(row: &str) -> String {
    row.chars().map(|ch| match ch {
        '*' => '*',
        _ => ' '
    }).collect()
}

fn run_test(test_case: &[&str]) {
    let cleaned = remove_annotations(test_case);
    let cleaned_strs = cleaned.iter().map(|r| &r[..]).collect::<Vec<_>>();
    let expected = test_case.iter().map(|&r| r.to_string()).collect::<Vec<_>>();
    assert_eq!(expected, annotate(&cleaned_strs));
}
PREAMBLE

data['cases'].each_with_index { |c, i|
  puts
  puts '#[test]'
  puts '#[ignore]' if i != 0
  puts "fn #{c['description'].tr(' ', ?_).delete(?,).downcase}() {"
  puts '    run_test(&['
  c['expected'].each { |l|
    puts "        \"#{l}\","
  }
  puts '    ]);'
  puts ?}
}
```