### PR TITLE
etl 1.0.0: use single characters only

### DIFF
--- a/exercises/etl/Cargo.lock
+++ b/exercises/etl/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "etl"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/etl/Cargo.toml
+++ b/exercises/etl/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "etl"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/etl/example.rs
+++ b/exercises/etl/example.rs
@@ -1,8 +1,8 @@
 use std::ascii::AsciiExt;
 use std::collections::BTreeMap;
 
-pub fn transform(input: &BTreeMap<i32, Vec<String>>) -> BTreeMap<String, i32> {
+pub fn transform(input: &BTreeMap<i32, Vec<char>>) -> BTreeMap<char, i32> {
     input.iter().flat_map(|(&n, vec)| {
-        vec.iter().map(move |s| (s.to_ascii_lowercase(), n))
+        vec.iter().map(move |c| (c.to_ascii_lowercase(), n))
     }).collect()
 }

--- a/exercises/etl/tests/etl.rs
+++ b/exercises/etl/tests/etl.rs
@@ -5,11 +5,11 @@ use std::collections::BTreeMap;
 #[test]
 fn test_transform_one_value() {
     let input = input_from(&[
-        (1, vec!("WORLD")),
+        (1, vec!('A')),
     ]);
 
     let expected = expected_from(&[
-        ("world", 1),
+        ('a', 1),
     ]);
 
     assert_eq!(expected, etl::transform(&input));
@@ -19,11 +19,11 @@ fn test_transform_one_value() {
 #[ignore]
 fn test_transform_more_values() {
     let input = input_from(&[
-        (1, vec!("WORLD", "GSCHOOLERS")),
+        (1, vec!('A', 'E', 'I', 'O', 'U')),
     ]);
 
     let expected = expected_from(&[
-        ("world", 1), ("gschoolers", 1),
+        ('a', 1), ('e', 1), ('i', 1), ('o', 1), ('u', 1),
     ]);
 
     assert_eq!(expected, etl::transform(&input));
@@ -33,13 +33,13 @@ fn test_transform_more_values() {
 #[ignore]
 fn test_more_keys() {
     let input = input_from(&[
-        (1, vec!("APPLE", "ARTICHOKE")),
-        (2, vec!("BOAT", "BALLERINA")),
+        (1, vec!('A', 'E')),
+        (2, vec!('D', 'G')),
     ]);
 
     let expected = expected_from(&[
-        ("apple", 1), ("artichoke", 1),
-        ("boat",  2), ("ballerina", 2),
+        ('a', 1), ('e', 1),
+        ('d',  2), ('g', 2),
     ]);
 
     assert_eq!(expected, etl::transform(&input));
@@ -49,38 +49,32 @@ fn test_more_keys() {
 #[ignore]
 fn test_full_dataset() {
     let input = input_from(&[
-        (1,  vec!("A", "E", "I", "O", "U", "L", "N", "R", "S", "T")),
-        (2,  vec!("D", "G")),
-        (3,  vec!("B", "C", "M", "P")),
-        (4,  vec!("F", "H", "V", "W", "Y")),
-        (5,  vec!("K")),
-        (8,  vec!("J", "X")),
-        (10, vec!("Q", "Z")),
+        (1,  vec!('A', 'E', 'I', 'O', 'U', 'L', 'N', 'R', 'S', 'T')),
+        (2,  vec!('D', 'G')),
+        (3,  vec!('B', 'C', 'M', 'P')),
+        (4,  vec!('F', 'H', 'V', 'W', 'Y')),
+        (5,  vec!('K')),
+        (8,  vec!('J', 'X')),
+        (10, vec!('Q', 'Z')),
     ]);
 
     let expected = expected_from(&[
-        ("a",  1), ("b",  3), ("c",  3), ("d",  2),
-        ("e",  1), ("f",  4), ("g",  2), ("h",  4),
-        ("i",  1), ("j",  8), ("k",  5), ("l",  1),
-        ("m",  3), ("n",  1), ("o",  1), ("p",  3),
-        ("q", 10), ("r",  1), ("s",  1), ("t",  1),
-        ("u",  1), ("v",  4), ("w",  4), ("x",  8),
-        ("y",  4), ("z", 10),
+        ('a',  1), ('b',  3), ('c',  3), ('d',  2),
+        ('e',  1), ('f',  4), ('g',  2), ('h',  4),
+        ('i',  1), ('j',  8), ('k',  5), ('l',  1),
+        ('m',  3), ('n',  1), ('o',  1), ('p',  3),
+        ('q', 10), ('r',  1), ('s',  1), ('t',  1),
+        ('u',  1), ('v',  4), ('w',  4), ('x',  8),
+        ('y',  4), ('z', 10),
     ]);
 
     assert_eq!(expected, etl::transform(&input));
 }
 
-fn input_from(v: &[(i32, Vec<&str>)]) -> BTreeMap<i32, Vec<String>> {
-    v.iter().fold(BTreeMap::new(), |mut acc, &(n, ref v)| {
-        acc.insert(n, v.iter().map(|s| s.to_string()).collect());
-        acc
-    })
+fn input_from(v: &[(i32, Vec<char>)]) -> BTreeMap<i32, Vec<char>> {
+    v.iter().cloned().collect()
 }
 
-fn expected_from(v: &[(&str, i32)]) -> BTreeMap<String, i32> {
-    v.iter().fold(BTreeMap::new(), |mut acc, &(s, n)| {
-        acc.insert(s.to_string(), n);
-        acc
-    })
+fn expected_from(v: &[(char, i32)]) -> BTreeMap<char, i32> {
+    v.iter().cloned().collect()
 }


### PR DESCRIPTION
https://github.com/exercism/x-common/blob/master/exercises/etl/description.md
tells us that we are only working with single letters. In Rust, we would
represent these as characters.

However, ever since #33 the Rust track has used strings.

It doesn't seem right to stray from the standard description. In using
characters, we don't lose too much except perhaps deal with String
lifetimes.