### PR TITLE
rna-transcription 1.0.0: reject invalid inputs

### DIFF
--- a/config.json
+++ b/config.json
@@ -214,6 +214,7 @@
       "slug": "rna-transcription",
       "difficulty": 4,
       "topics": [
+        "Result",
         "match",
         "struct",
         "str vs string"

--- a/exercises/rna-transcription/Cargo.lock
+++ b/exercises/rna-transcription/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "rna-transcription"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/rna-transcription/Cargo.toml
+++ b/exercises/rna-transcription/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "rna-transcription"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/rna-transcription/example.rs
+++ b/exercises/rna-transcription/example.rs
@@ -14,13 +14,13 @@ pub struct DeoxyribonucleicAcid {
     nucleotides: String
 }
 
-fn transcribe_dna_rna(c: char) -> char {
+fn transcribe_dna_rna(c: char) -> Option<char> {
     match c {
-        'C' => 'G',
-        'G' => 'C',
-        'A' => 'U',
-        'T' => 'A',
-        _   => c
+        'C' => Some('G'),
+        'G' => Some('C'),
+        'A' => Some('U'),
+        'T' => Some('A'),
+        _   => None
     }
 }
 
@@ -30,7 +30,11 @@ impl DeoxyribonucleicAcid {
     }
 
     pub fn to_rna(&self) -> Result<RibonucleicAcid, ()> {
-        let rna_nucleotides = self.nucleotides.chars().map(transcribe_dna_rna).collect();
-        Ok(RibonucleicAcid { nucleotides: rna_nucleotides })
+        let rna_nucleotides: String = self.nucleotides.chars().filter_map(transcribe_dna_rna).collect();
+        if rna_nucleotides.len() == self.nucleotides.len() {
+            Ok(RibonucleicAcid { nucleotides: rna_nucleotides })
+        } else {
+            Err(())
+        }
     }
 }

--- a/exercises/rna-transcription/example.rs
+++ b/exercises/rna-transcription/example.rs
@@ -29,8 +29,8 @@ impl DeoxyribonucleicAcid {
         DeoxyribonucleicAcid { nucleotides: nucleotides.to_string() }
     }
 
-    pub fn to_rna(&self) -> RibonucleicAcid {
+    pub fn to_rna(&self) -> Result<RibonucleicAcid, ()> {
         let rna_nucleotides = self.nucleotides.chars().map(transcribe_dna_rna).collect();
-        RibonucleicAcid { nucleotides: rna_nucleotides }
+        Ok(RibonucleicAcid { nucleotides: rna_nucleotides })
     }
 }

--- a/exercises/rna-transcription/tests/rna-transcription.rs
+++ b/exercises/rna-transcription/tests/rna-transcription.rs
@@ -35,3 +35,21 @@ fn test_transcribes_thymine_to_adenine() {
 fn test_transcribes_all_dna_to_rna() {
     assert_eq!(Ok(dna::RibonucleicAcid::new("UGCACCAGAAUU")), dna::DeoxyribonucleicAcid::new("ACGTGGTCTTAA").to_rna())
 }
+
+#[test]
+#[ignore]
+fn handles_invalid_input() {
+    assert!(dna::DeoxyribonucleicAcid::new("U").to_rna().is_err());
+}
+
+#[test]
+#[ignore]
+fn handles_completely_invalid_input() {
+    assert!(dna::DeoxyribonucleicAcid::new("XXX").to_rna().is_err());
+}
+
+#[test]
+#[ignore]
+fn handles_partially_invalid_input() {
+    assert!(dna::DeoxyribonucleicAcid::new("ACGTXXXCTTAA").to_rna().is_err());
+}

--- a/exercises/rna-transcription/tests/rna-transcription.rs
+++ b/exercises/rna-transcription/tests/rna-transcription.rs
@@ -9,29 +9,29 @@ fn test_acid_equals_acid() {
 #[test]
 #[ignore]
 fn test_transcribes_cytosine_guanine() {
-    assert_eq!(dna::RibonucleicAcid::new("G"), dna::DeoxyribonucleicAcid::new("C").to_rna());
+    assert_eq!(Ok(dna::RibonucleicAcid::new("G")), dna::DeoxyribonucleicAcid::new("C").to_rna());
 }
 
 #[test]
 #[ignore]
 fn test_transcribes_guanine_cytosine() {
-    assert_eq!(dna::RibonucleicAcid::new("C"), dna::DeoxyribonucleicAcid::new("G").to_rna());
+    assert_eq!(Ok(dna::RibonucleicAcid::new("C")), dna::DeoxyribonucleicAcid::new("G").to_rna());
 }
 
 #[test]
 #[ignore]
 fn test_transcribes_adenine_uracil() {
-    assert_eq!(dna::RibonucleicAcid::new("U"), dna::DeoxyribonucleicAcid::new("A").to_rna());
+    assert_eq!(Ok(dna::RibonucleicAcid::new("U")), dna::DeoxyribonucleicAcid::new("A").to_rna());
 }
 
 #[test]
 #[ignore]
 fn test_transcribes_thymine_to_adenine() {
-    assert_eq!(dna::RibonucleicAcid::new("A"), dna::DeoxyribonucleicAcid::new("T").to_rna());
+    assert_eq!(Ok(dna::RibonucleicAcid::new("A")), dna::DeoxyribonucleicAcid::new("T").to_rna());
 }
 
 #[test]
 #[ignore]
 fn test_transcribes_all_dna_to_rna() {
-    assert_eq!(dna::RibonucleicAcid::new("UGCACCAGAAUU"), dna::DeoxyribonucleicAcid::new("ACGTGGTCTTAA").to_rna())
+    assert_eq!(Ok(dna::RibonucleicAcid::new("UGCACCAGAAUU")), dna::DeoxyribonucleicAcid::new("ACGTGGTCTTAA").to_rna())
 }


### PR DESCRIPTION
The invalid input cases originally came from
exercism/x-common#119

Today's JSON file can be found at
https://github.com/exercism/x-common/blob/master/exercises/rna-transcription/canonical-data.json

This track was already using all the valid inputs and simply needed to
add these invalid inputs.