### PR TITLE
raindrops 1.0.0: Add 8, 27, 3125

### DIFF
--- a/exercises/raindrops/Cargo.lock
+++ b/exercises/raindrops/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "raindrops"
-version = "0.0.0"
+version = "1.0.0"
 

--- a/exercises/raindrops/Cargo.toml
+++ b/exercises/raindrops/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "raindrops"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/raindrops/tests/raindrops.rs
+++ b/exercises/raindrops/tests/raindrops.rs
@@ -21,6 +21,10 @@ fn test_6() { assert_eq!("Pling", raindrops::raindrops(6)); }
 
 #[test]
 #[ignore]
+fn test_8() { assert_eq!("8", raindrops::raindrops(8)); }
+
+#[test]
+#[ignore]
 fn test_9() { assert_eq!("Pling", raindrops::raindrops(9)); }
 
 #[test]
@@ -45,6 +49,10 @@ fn test_25() { assert_eq!("Plang", raindrops::raindrops(25)); }
 
 #[test]
 #[ignore]
+fn test_27() { assert_eq!("Pling", raindrops::raindrops(27)); }
+
+#[test]
+#[ignore]
 fn test_35() { assert_eq!("PlangPlong", raindrops::raindrops(35)); }
 
 #[test]
@@ -58,6 +66,10 @@ fn test_52() { assert_eq!("52", raindrops::raindrops(52)); }
 #[test]
 #[ignore]
 fn test_105() { assert_eq!("PlingPlangPlong", raindrops::raindrops(105)); }
+
+#[test]
+#[ignore]
+fn test_3125() { assert_eq!("Plang", raindrops::raindrops(3125)); }
 
 #[test]
 #[ignore]


### PR DESCRIPTION
Added in https://github.com/exercism/x-common/pull/370

Although I doubt anyone will make the same mistake in this language, I
don't care enough to declare that we should elide these cases.

Note that even though Rust now has the same cases as 1.0.0, we don't
have descriptions like in https://github.com/exercism/x-common/pull/450.
I don't find them terribly necessary, but I suppose they can be added if
they seem good.

We would likely no longer be able to have the tests on one line in that
case, since some descriptions are rather long.