### PR TITLE
README: link to contributing docs in docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Exercism exercises in Rust
 
 ## Contributing Guide
 
-Please see the [contributing guide](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md)
+Please see the [contributing guide](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks)
 
 
 ## Rust icon


### PR DESCRIPTION
Because documentation items are being moved to the docs repo and thus
being removed from x-common's CONTRIBUTING file, it makes less sense to
link to the latter.

It is acknowledged that this is not a full solution to #278. That is a
larger project than this necessary move.