### PR TITLE
Delete ignored key from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -502,11 +502,6 @@
     "nucleotide-codons",
     "hexadecimal"
   ],
-  "ignored": [
-    "_test",
-    "docs",
-    "img"
-  ],
   "foregone": [
     "binary",
     "octal",


### PR DESCRIPTION
Since the exercise implementations are all in the exercises directory
we no longer need to ignore any non-exercise directories in the root
of the track.

See https://github.com/exercism/meta/issues/3 for context.