### PR TITLE
Remove tests for compression & added tests for of_rna

### DIFF
--- a/exercises/protein-translation/example.rs
+++ b/exercises/protein-translation/example.rs
@@ -12,29 +12,18 @@ pub fn parse<'a>(pairs: Vec<(&'a str, &'a str)>) -> CodonInfo<'a> {
 
 impl<'a> CodonInfo<'a> {
     pub fn name_for(&self, codon: &str) -> Result<&'a str, &'static str> {
-        if codon.len() != 3 {
-            return Err("invalid length")
+        match self.actual_codons.get(&codon) {
+            Some(name) => Ok(name),
+            None => Err("Invalid")
         }
+    }
 
-        let mut valid = true;
-        let lookup: String = codon.chars().map(|l| {
-            // Get an example of a "letter" represented by the possibly encoded letter.
-            // Since every codon represented by the compressed notation has to be of
-            // the desired amino acid just picking one at random will do.
-            match l {
-                'A' | 'W' | 'M' | 'R' | 'D' | 'H' | 'V' | 'N' => 'A',
-                'C' | 'S' | 'Y' | 'B' => 'C',
-                'G' | 'K' => 'G',
-                'T' => 'T',
-                _ => { valid = false; ' ' }
-            }
-        }).collect();
-        if !valid {
-            return Err("invalid char")
-        }
-
-        // If the input table is correct (which it is) every valid codon is in it
-        // so unwrap() shouldn't panic.
-        Ok(self.actual_codons.get(&lookup.as_ref()).unwrap())
+    pub fn of_rna(&self, strand: &str) -> Result<Vec<&'a str>, &'static str> {
+        strand.chars()
+            .collect::<Vec<char>>()
+            .chunks(3)
+            .map(|chars| self.name_for(&chars.iter().collect::<String>()))
+            .take_while(|result| result.is_err() || result.unwrap() != "stop codon")
+            .collect()
     }
 }

--- a/exercises/protein-translation/tests/proteins.rs
+++ b/exercises/protein-translation/tests/proteins.rs
@@ -15,14 +15,6 @@ fn test_cysteine_tgt() {
 
 #[test]
 #[ignore]
-fn test_cysteine_tgy() { // "compressed" name for TGT and TGC
-    let info = proteins::parse(make_pairs());
-    assert_eq!(info.name_for("TGT"), info.name_for("TGY"));
-    assert_eq!(info.name_for("TGC"), info.name_for("TGY"));
-}
-
-#[test]
-#[ignore]
 fn test_stop() {
     let info = proteins::parse(make_pairs());
     assert_eq!(info.name_for("TAA"), Ok("stop codon"));
@@ -32,25 +24,23 @@ fn test_stop() {
 #[ignore]
 fn test_valine() {
     let info = proteins::parse(make_pairs());
-    assert_eq!(info.name_for("GTN"), Ok("valine"));
+    assert_eq!(info.name_for("GTT"), Ok("valine"));
 }
-
 
 #[test]
 #[ignore]
 fn test_isoleucine() {
     let info = proteins::parse(make_pairs());
-    assert_eq!(info.name_for("ATH"), Ok("isoleucine"));
+    assert_eq!(info.name_for("ATT"), Ok("isoleucine"));
 }
 
 #[test]
 #[ignore]
 fn test_arginine_name() {
-    // In arginine CGA can be "compresed" both as CGN and as MGR
     let info = proteins::parse(make_pairs());
     assert_eq!(info.name_for("CGA"), Ok("arginine"));
-    assert_eq!(info.name_for("CGN"), Ok("arginine"));
-    assert_eq!(info.name_for("MGR"), Ok("arginine"));
+    assert_eq!(info.name_for("AGA"), Ok("arginine"));
+    assert_eq!(info.name_for("AGG"), Ok("arginine"));
 }
 
 #[test]
@@ -81,22 +71,53 @@ fn too_long_is_invalid() {
     assert!(info.name_for("ATTA").is_err());
 }
 
+#[test]
+#[ignore]
+fn test_translates_rna_strand_into_correct_protein() {
+    let info = proteins::parse(make_pairs());
+    assert_eq!(info.of_rna("AUGUUUUGG").unwrap(),
+               vec!["methionine", "phenylalanine", "tryptophan"]);
+}
+
+#[test]
+#[ignore]
+fn test_stops_translation_if_stop_codon_present() {
+    let info = proteins::parse(make_pairs());
+    assert_eq!(info.of_rna("AUGUUUUAA").unwrap(),
+               vec!["methionine", "phenylalanine"]);
+}
+
+#[test]
+#[ignore]
+fn test_stops_translation_of_longer_strand() {
+    let info = proteins::parse(make_pairs());
+    assert_eq!(info.of_rna("UGGUGUUAUUAAUGGUUU").unwrap(),
+               vec!["tryptophan", "cysteine", "tyrosine"]);
+}
+
+#[test]
+#[ignore]
+fn test_invalid_codons() {
+    let info = proteins::parse(make_pairs());
+    assert!(info.of_rna("CARROT").is_err());
+}
+
 // The input data constructor. Returns a list of codon, name pairs.
 fn make_pairs() -> Vec<(&'static str, &'static str)> {
     let grouped = vec![
         ("isoleucine", vec!["ATT", "ATC", "ATA"]),
         ("leucine", vec!["CTT", "CTC", "CTA", "CTG", "TTA", "TTG"]),
         ("valine", vec!["GTT", "GTC", "GTA", "GTG"]),
-        ("phenylalanine", vec!["TTT", "TTC"]),
-        ("methionine", vec!["ATG"]),
-        ("cysteine", vec!["TGT", "TGC"]),
+        ("phenylalanine", vec!["UUU", "TTT", "TTC"]),
+        ("methionine", vec!["AUG", "ATG"]),
+        ("cysteine", vec!["UGU", "TGT", "TGC"]),
         ("alanine", vec!["GCT", "GCC", "GCA", "GCG"]),
         ("glycine", vec!["GGT", "GGC", "GGA", "GGG"]),
         ("proline", vec!["CCT", "CCC", "CCA", "CCG"]),
         ("threonine", vec!["ACT", "ACC", "ACA", "ACG"]),
         ("serine", vec!["TCT", "TCC", "TCA", "TCG", "AGT", "AGC"]),
-        ("tyrosine", vec!["TAT", "TAC"]),
-        ("tryptophan", vec!["TGG"]),
+        ("tyrosine", vec!["UAU", "TAT", "TAC"]),
+        ("tryptophan", vec!["UGG", "TGG"]),
         ("glutamine", vec!["CAA", "CAG"]),
         ("asparagine", vec!["AAT", "AAC"]),
         ("histidine", vec!["CAT", "CAC"]),
@@ -104,7 +125,7 @@ fn make_pairs() -> Vec<(&'static str, &'static str)> {
         ("aspartic acid", vec!["GAT", "GAC"]),
         ("lysine", vec!["AAA", "AAG"]),
         ("arginine", vec!["CGT", "CGC", "CGA", "CGG", "AGA", "AGG"]),
-        ("stop codon", vec!["TAA", "TAG", "TGA"])];
+        ("stop codon", vec!["UAA", "TAA", "TAG", "TGA"])];
     let mut pairs = Vec::<(&'static str, &'static str)>::new();
     for (name, codons) in grouped.into_iter() {
         for codon in codons {


### PR DESCRIPTION
This resolves https://github.com/exercism/xrust/issues/267
* removed test cases that tested for compression because README did not mention about it
* added test cases for function `of_rna`, which are copied from [xpython](https://github.com/exercism/xpython/blob/master/exercises/protein-translation/protein_translation_test.py)